### PR TITLE
Fix Tetris catalog play URL

### DIFF
--- a/games.json
+++ b/games.json
@@ -54,7 +54,7 @@
     ],
     "difficulty": "medium",
     "released": "2025-08-26",
-    "playUrl": "/games/tetris/",
+    "playUrl": "/games/tetris/play.html",
     "firstFrame": {
       "audio": [
         "/assets/audio/hit.wav",


### PR DESCRIPTION
## Summary
- point the Tetris catalog entry at the standalone play.html surface so the shell loads the right page

## Testing
- Manual QA

------
https://chatgpt.com/codex/tasks/task_e_68df75e766048327a2663542a7ba5724