### PR TITLE
Load SFX helpers before snake module

### DIFF
--- a/gameshells/snake/index.html
+++ b/gameshells/snake/index.html
@@ -32,6 +32,7 @@
       });
     </script>
     <script src="../../js/gameUtil.js"></script>
+    <script src="../../js/sfx.js"></script>
     <script type="module" src="../../games/snake/snake.js"></script>
   
 <!-- Auto-signal bootstrap: emits READY/ERROR to parent -->


### PR DESCRIPTION
## Summary
- add the legacy sfx helper script to the snake shell before the module load so window.SFX is defined

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9058441483278198b9a60fc6bc8a