### PR TITLE
feat: enhance asteroids visuals and audio

### DIFF
--- a/games/asteroids/index.html
+++ b/games/asteroids/index.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Asteroids Pro</title>
   <link rel="preload" href="../../assets/sprites/ship.png" as="image" />
-  <link rel="preload" href="../../assets/audio/hit.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/laser.wav" as="audio" />
   <link rel="preload" href="../../assets/audio/explode.wav" as="audio" />
   <link rel="preload" href="../../assets/audio/powerup.wav" as="audio" />
+  <link rel="preload" href="../../assets/audio/gameover.wav" as="audio" />
   <link rel="stylesheet" href="../common/game-shell.css" />
   <style>
     :root {


### PR DESCRIPTION
## Summary
- preload the new background, projectile, explosion, and shield art for Asteroids and cache reusable sprites
- replace vector bullets with sprite rendering, animate explosion frames, and draw the shield while invulnerable
- hook up laser and gameover audio cues alongside existing sounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe86057ec8327810f41db98f771e3