### PR TITLE
Revamp Tetris rendering with shared sprites and effects

### DIFF
--- a/data/games-offline.js
+++ b/data/games-offline.js
@@ -57,6 +57,12 @@ export const games = [
     "released": "2025-08-26",
     "playUrl": "/games/tetris/",
     "firstFrame": {
+      "sprites": [
+        "/assets/sprites/block.png",
+        "/assets/backgrounds/arcade.png",
+        "/assets/effects/spark.png",
+        "/assets/effects/explosion.png"
+      ],
       "audio": [
         "/assets/audio/hit.wav",
         "/assets/audio/powerup.wav",

--- a/games.json
+++ b/games.json
@@ -84,6 +84,12 @@
     "released": "2025-08-26",
     "playUrl": "/games/tetris/play.html",
     "firstFrame": {
+      "sprites": [
+        "/assets/sprites/block.png",
+        "/assets/backgrounds/arcade.png",
+        "/assets/effects/spark.png",
+        "/assets/effects/explosion.png"
+      ],
       "audio": [
         "/assets/audio/hit.wav",
         "/assets/audio/powerup.wav",


### PR DESCRIPTION
## Summary
- preload shared Tetris sprites and draw the board with tinted block sprites over the arcade background
- add sprite-driven spark and explosion effects for locks, hard drops, and line clears with updated clear timing
- route gameplay events through shared audio helpers and register the sprites in the catalog metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfecdc0a2c8327a360b3a128cfd5dc