### PR TITLE
Apply pixel art panels to pause/help overlays

### DIFF
--- a/shared/pauseOverlay.js
+++ b/shared/pauseOverlay.js
@@ -100,10 +100,14 @@
     const restartLabel = options.restartLabel || 'Restart';
 
     overlay.innerHTML = `
-      <div class="panel" role="document">
-        <h3 style="margin:0 0 12px 0; font: 700 18px Inter,system-ui">${heading}</h3>
-        <p class="hint" style="margin:0 0 16px 0; font:500 14px/1.4 Inter,system-ui; color:var(--muted,#9aa0a6);">${hint}</p>
-        <div style="display:flex; gap:10px; justify-content:center">
+      <div class="pixel-panel pixel-panel--pause" role="document">
+        <div class="pixel-panel__header">
+          <span class="pixel-panel__icon pixel-panel__icon--star" aria-hidden="true"></span>
+          <h3 class="pixel-panel__title">${heading}</h3>
+          <span class="pixel-panel__icon pixel-panel__icon--shield" aria-hidden="true"></span>
+        </div>
+        <p class="pixel-panel__hint">${hint}</p>
+        <div class="pixel-panel__actions">
           <button type="button" class="btn" data-action="resume">${resumeLabel}</button>
           <button type="button" class="btn" data-action="restart">${restartLabel}</button>
         </div>
@@ -117,7 +121,8 @@
 
     const resumeBtn = overlay.querySelector('[data-action="resume"]');
     const restartBtn = overlay.querySelector('[data-action="restart"]');
-    const hintEl = overlay.querySelector('.hint');
+    const hintEl = overlay.querySelector('.pixel-panel__hint');
+    if (hintEl && !hint) hintEl.hidden = true;
 
     function hide() { overlay.classList.add('hidden'); }
     function show() {
@@ -140,7 +145,10 @@
       hide,
       element: overlay,
       setHint(text) {
-        if (hintEl && typeof text === 'string') hintEl.textContent = text;
+        if (hintEl && typeof text === 'string') {
+          hintEl.textContent = text;
+          hintEl.hidden = !text.trim();
+        }
       }
     };
   }

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -169,9 +169,13 @@ export function attachPauseOverlay({ onResume, onRestart }) {
   const overlay = document.createElement('div');
   overlay.className = 'pause-overlay hidden';
   overlay.innerHTML = `
-    <div class="panel">
-      <h3 style="margin:0 0 12px 0; font: 700 18px Inter,system-ui">${t('paused')}</h3>
-      <div style="display:flex; gap:10px; justify-content:center">
+    <div class="pixel-panel pixel-panel--pause" role="document">
+      <div class="pixel-panel__header">
+        <span class="pixel-panel__icon pixel-panel__icon--star" aria-hidden="true"></span>
+        <h3 class="pixel-panel__title">${t('paused')}</h3>
+        <span class="pixel-panel__icon pixel-panel__icon--shield" aria-hidden="true"></span>
+      </div>
+      <div class="pixel-panel__actions">
         <button id="resumeBtn" class="btn">${t('resume')}</button>
         <button id="restartBtn" class="btn">${t('restart')}</button>
       </div>
@@ -190,14 +194,21 @@ export function attachHelpOverlay({ gameId, steps = [], objective = '', controls
   overlay.setAttribute('role', 'dialog');
   overlay.setAttribute('aria-modal', 'true');
   overlay.innerHTML = `
-    <div class="panel">
+    <div class="pixel-panel pixel-panel--help" role="document">
       <button class="close-icon" aria-label="${t('close')}">\u00d7</button>
-      <div class="step-content"></div>
-      <div class="footer">
-        <span class="step-indicator"></span>
-        <div class="actions">
-          <button class="btn next-btn">${t('next')}</button>
-          <button class="btn close-btn">${t('close')}</button>
+      <div class="pixel-panel__header">
+        <span class="pixel-panel__icon pixel-panel__icon--star" aria-hidden="true"></span>
+        <h3 class="pixel-panel__title">${t('help')}</h3>
+        <span class="pixel-panel__icon pixel-panel__icon--shield" aria-hidden="true"></span>
+      </div>
+      <div class="pixel-panel__body">
+        <div class="step-content"></div>
+        <div class="footer">
+          <span class="step-indicator"></span>
+          <div class="actions">
+            <button class="btn next-btn">${t('next')}</button>
+            <button class="btn close-btn">${t('close')}</button>
+          </div>
         </div>
       </div>
     </div>`;

--- a/styles.css
+++ b/styles.css
@@ -133,17 +133,6 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
   z-index:999;
 }
 .pause-overlay.hidden { display:none; }
-.pause-overlay .panel {
-  background: var(--panel-bg);
-  color: var(--panel-fg);
-  padding:24px;
-  border-radius:12px;
-  min-width:220px;
-  text-align:center;
-  box-shadow: 0 10px 40px rgba(0,0,0,0.45);
-}
-.pause-overlay button { margin:6px; }
-
 /* Help overlay */
 .help-overlay {
   position:fixed;
@@ -155,33 +144,113 @@ main { max-width:1100px; margin:0 auto; padding:16px; }
   z-index:999;
 }
 .help-overlay.hidden { display:none; }
-.help-overlay .panel {
-  position:relative;
-  background: var(--panel-bg);
-  color: var(--panel-fg);
-  padding:24px;
-  border-radius:12px;
-  max-width:360px;
-  text-align:left;
-  box-shadow: 0 10px 40px rgba(0,0,0,0.45);
-}
 .help-overlay section { margin-bottom:12px; }
 .help-overlay h4 { margin:0 0 4px 0; font:700 16px var(--font-brand); }
 .help-overlay .footer { display:flex; justify-content:space-between; align-items:center; margin-top:12px; }
 .help-overlay .footer .actions { display:flex; gap:6px; }
 .help-overlay .step-indicator { font-size:14px; opacity:.8; }
-.help-overlay button { margin-left:6px; }
-
+.help-overlay .step-content { display:flex; flex-direction:column; gap:12px; }
+.help-overlay .step-content ul { margin:0; padding-left:20px; }
 .help-overlay .close-icon {
   position:absolute;
-  top:8px;
-  right:8px;
+  top:12px;
+  right:12px;
   background:none;
   border:none;
   font-size:18px;
   line-height:1;
   cursor:pointer;
   margin:0;
+}
+
+.pixel-panel {
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:16px;
+  padding:32px 36px 28px;
+  min-width:240px;
+  max-width:400px;
+  width:min(90vw, 400px);
+  background: url('/assets/ui/panel.png') center / 100% 100% no-repeat;
+  image-rendering: pixelated;
+  color: var(--panel-fg);
+  text-align:center;
+  border-radius:0;
+  box-shadow: 0 18px 40px rgba(0,0,0,0.5);
+}
+
+.pixel-panel--help {
+  align-items:stretch;
+  text-align:left;
+  padding:36px 40px;
+  max-width:460px;
+  width:min(92vw, 460px);
+}
+
+.pixel-panel--pause {
+  max-width:320px;
+  width:min(85vw, 320px);
+}
+
+.pixel-panel__header {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:14px;
+  width:100%;
+}
+
+.pixel-panel__title {
+  margin:0;
+  font:700 20px var(--font-brand);
+  text-align:center;
+}
+
+.pixel-panel__body {
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  width:100%;
+}
+
+.pixel-panel__actions {
+  display:flex;
+  gap:12px;
+  justify-content:center;
+  flex-wrap:wrap;
+  width:100%;
+  margin-top:8px;
+}
+
+.pixel-panel__hint {
+  margin:0;
+  font:500 14px/1.4 var(--font-sans);
+  color: var(--muted, #9aa0a6);
+  text-align:center;
+}
+
+.pixel-panel--help .pixel-panel__body {
+  text-align:left;
+}
+
+.pixel-panel__icon {
+  width:32px;
+  height:32px;
+  background-repeat:no-repeat;
+  background-size:contain;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 2px 0 rgba(0,0,0,0.35));
+  flex-shrink:0;
+}
+
+.pixel-panel__icon--star { background-image:url('/assets/ui/star.png'); }
+.pixel-panel__icon--shield { background-image:url('/assets/powerups/shield.png'); }
+
+.help-overlay .footer {
+  align-items:center;
+  gap:12px;
 }
 
 /* Utility badges/tags */


### PR DESCRIPTION
## Summary
- restyle pause and help overlays to use the shared pixel-art panel frame with decorative star and shield icons
- update overlay markup to include structured header, body, and action sections for the new art assets
- refresh shared pause overlay helper to expose the hint element safely while supporting the updated styling

## Testing
- npm run test:smoke *(fails: RunnerGame.draw expects a canvas context with translate())*

------
https://chatgpt.com/codex/tasks/task_e_68dfed00f8d083278408f720571b53c7