### PR TITLE
Optimize particle cleanup in canvas FX system

### DIFF
--- a/shared/fx/canvasFx.js
+++ b/shared/fx/canvasFx.js
@@ -27,7 +27,11 @@ export function createParticleSystem(ctx) {
       p.vx *= p.decay;
       p.vy *= p.decay;
       p.life--;
-      if (p.life <= 0) particles.splice(i, 1);
+      if (p.life <= 0) {
+        const lastIndex = particles.length - 1;
+        if (i !== lastIndex) particles[i] = particles[lastIndex];
+        particles.pop();
+      }
     }
   }
   function draw() {


### PR DESCRIPTION
## Summary
- replace splice-based particle removal with a swap-and-pop strategy in the canvas particle system to avoid array compaction overhead
- verified particle array contiguity while exercising draw logic under heavy particle counts

## Testing
- `node --input-type=module <<'NODE' ... NODE`
- `npm test` *(fails: jsdom lacks HTMLMediaElement.load; runner smoke test needs translate-capable canvas; sw cache test expects cache API)*

------
https://chatgpt.com/codex/tasks/task_e_68dff85ac1248327aca407fdce3e6f96