### PR TITLE
Cache landing timestamps during adaptation

### DIFF
--- a/js/catalog-utils.js
+++ b/js/catalog-utils.js
@@ -1,0 +1,66 @@
+export function normalizeTimestamp(value){
+  if(value==null)return 0;
+  if(value instanceof Date){
+    const t=value.getTime();
+    return Number.isNaN(t)?0:t;
+  }
+  if(typeof value==='number'){
+    if(!Number.isFinite(value))return 0;
+    if(Math.abs(value)>=1e12)return value;
+    if(Math.abs(value)>=1e9)return value*1000;
+    if(Math.abs(value)>=1e6)return value*1000;
+    return 0;
+  }
+  if(typeof value==='string'){
+    const trimmed=value.trim();
+    if(!trimmed)return 0;
+    const asNumber=Number(trimmed);
+    if(Number.isFinite(asNumber))return normalizeTimestamp(asNumber);
+    const parsed=Date.parse(trimmed);
+    return Number.isNaN(parsed)?0:parsed;
+  }
+  return 0;
+}
+
+export function deriveComparableTimestamp(game){
+  if(!game||typeof game!=='object')return 0;
+  const candidates=[
+    game.addedAt,
+    game.added_at,
+    game.released,
+    game.releaseDate,
+    game.release_date,
+    game.publishedAt,
+    game.published_at,
+    game.updatedAt,
+    game.updated_at,
+    game.createdAt,
+    game.created_at,
+    game.date
+  ];
+  for(const value of candidates){
+    const stamp=normalizeTimestamp(value);
+    if(stamp)return stamp;
+  }
+  return 0;
+}
+
+export function adaptGameForLanding(raw){
+  if(!raw)return null;
+  const description=raw.description||raw.short||raw.desc||'';
+  const tags=Array.isArray(raw.tags)?raw.tags.filter(Boolean):[];
+  let path=raw.playPath||raw.path||raw.playUrl||raw.url||null;
+  if(!path&&raw.basePath){
+    const base=String(raw.basePath).replace(/\/+$/,'');
+    path=base&&base!=='/'?`${base}/index.html`:'/index.html';
+  }
+  const comparableTimestamp=deriveComparableTimestamp(raw);
+  return{
+    ...raw,
+    description,
+    desc:description,
+    tags,
+    path,
+    comparableTimestamp
+  };
+}

--- a/tests/catalog.sort-cache.test.js
+++ b/tests/catalog.sort-cache.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { adaptGameForLanding, deriveComparableTimestamp } from '../js/catalog-utils.js';
+
+describe('catalog timestamp caching', () => {
+  it('preserves newest sort order when using cached timestamps', () => {
+    const rawGames=[
+      { id:'alpha', title:'Alpha', description:'Oldest', addedAt:'2022-04-01' },
+      { id:'bravo', title:'Bravo', description:'Middle', release_date:'2023-09-15' },
+      { id:'charlie', title:'Charlie', description:'Newest', updatedAt:'2024-02-20' }
+    ];
+
+    const adapted=rawGames.map(adaptGameForLanding);
+
+    adapted.forEach(game=>{
+      expect(typeof game.comparableTimestamp).toBe('number');
+    });
+
+    const cachedOrder=[...adapted]
+      .sort((a,b)=>(b.comparableTimestamp??0)-(a.comparableTimestamp??0))
+      .map(g=>g.id);
+    const derivedOrder=[...adapted]
+      .sort((a,b)=>deriveComparableTimestamp(b)-deriveComparableTimestamp(a))
+      .map(g=>g.id);
+
+    expect(cachedOrder).toEqual(derivedOrder);
+  });
+});

--- a/tests/runner.smoke.test.js
+++ b/tests/runner.smoke.test.js
@@ -33,6 +33,10 @@ function installCanvasStub() {
     font: '',
     textAlign: '',
     globalAlpha: 1,
+    translate: vi.fn(),
+    scale: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
   };
   vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctxStub);
 }

--- a/tests/sw.test.js
+++ b/tests/sw.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import makeServiceWorkerEnv from 'service-worker-mock';
 
 const SW_SCOPE = 'tests';
-const CACHE_NAME = `gg-v3_2-${SW_SCOPE}`;
+const CACHE_NAME = `gg-v3_3-${SW_SCOPE}`;
 
 describe('service worker cache management', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- cache the derived comparable timestamp when adapting games for the landing page
- reuse the cached timestamp when sorting by newest to avoid recomputation
- add coverage for the cached sort order and update related test helpers

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dff8610ffc8327ac3f7abba023e458