### PR TITLE
Add parallax layers and animated sprites to platformer

### DIFF
--- a/shared/render/tileTextures.js
+++ b/shared/render/tileTextures.js
@@ -1,20 +1,32 @@
 const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
 
 const textureRegistry = Object.freeze({
-  block: Object.freeze({ src: '/assets/sprites/block.png', repeat: 'repeat' }),
-  brick: Object.freeze({ src: '/assets/sprites/brick.png', repeat: 'repeat' }),
-  lava: Object.freeze({ src: '/assets/sprites/lava.png', repeat: 'repeat-x' }),
+  block: Object.freeze({ src: '/assets/tilesets/grass.png', repeat: 'repeat' }),
+  brick: Object.freeze({ src: '/assets/tilesets/dirt.png', repeat: 'repeat' }),
+  lava: Object.freeze({ src: '/assets/tilesets/stone.png', repeat: 'repeat-x' }),
+});
+
+const keySprite = Object.freeze({
+  src: '/assets/sprites/collectibles/key.png',
+  frame: Object.freeze({ sx: 0, sy: 0, sw: 32, sh: 32 }),
+});
+
+const doorSprite = Object.freeze({
+  src: '/assets/sprites/collectibles/door.png',
+  frame: Object.freeze({ sx: 0, sy: 0, sw: 32, sh: 48 }),
+});
+
+const checkpointSprite = Object.freeze({
+  src: '/assets/sprites/collectibles/checkpoint_flag.png',
+  frame: Object.freeze({ sx: 0, sy: 0, sw: 32, sh: 48 }),
 });
 
 const spriteRegistry = Object.freeze({
-  coin: Object.freeze({
-    src: '/assets/sprites/coin.png',
-    frame: Object.freeze({ sx: 0, sy: 0, sw: 48, sh: 48 }),
-  }),
-  goal: Object.freeze({
-    src: '/assets/sprites/block.png',
-    frame: Object.freeze({ sx: 0, sy: 0, sw: 32, sh: 32 }),
-  }),
+  coin: keySprite,
+  key: keySprite,
+  goal: doorSprite,
+  door: doorSprite,
+  checkpoint: checkpointSprite,
 });
 
 const imageCache = new Map();


### PR DESCRIPTION
## Summary
- update shared texture and sprite definitions to use the new tileset and collectible artwork
- preload parallax forest layers and player animations in the platformer, drawing the background and animated characters
- size collectibles/goal from the new sprites, add a checkpoint prop, and render keys/door art while keeping collisions aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e004c7309483279987d9892ba2f531