### PR TITLE
Fix 2048 game entry id

### DIFF
--- a/games.json
+++ b/games.json
@@ -212,7 +212,7 @@
     }
   },
   {
-    "id": "g2048",
+    "id": "2048",
     "title": "2048",
     "short": "Slide numbers to reach 2048.",
     "tags": [


### PR DESCRIPTION
## Summary
- update the 2048 game's id in games.json to match the route slug

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e00be898208327833a08da477f6b39