### PR TITLE
Swap coin sprites to gem collectible art

### DIFF
--- a/shared/render/tileTextures.js
+++ b/shared/render/tileTextures.js
@@ -6,6 +6,11 @@ const textureRegistry = Object.freeze({
   lava: Object.freeze({ src: '/assets/tilesets/stone.png', repeat: 'repeat-x' }),
 });
 
+const gemSprite = Object.freeze({
+  src: '/assets/sprites/collectibles/gem_blue.png',
+  frame: Object.freeze({ sx: 0, sy: 0, sw: 32, sh: 32 }),
+});
+
 const keySprite = Object.freeze({
   src: '/assets/sprites/collectibles/key.png',
   frame: Object.freeze({ sx: 0, sy: 0, sw: 32, sh: 32 }),
@@ -22,7 +27,8 @@ const checkpointSprite = Object.freeze({
 });
 
 const spriteRegistry = Object.freeze({
-  coin: keySprite,
+  gem: gemSprite,
+  coin: gemSprite,
   key: keySprite,
   goal: doorSprite,
   door: doorSprite,
@@ -145,7 +151,9 @@ export function drawTileSprite(ctx, keyOrDef, dx, dy, dw, dh, frameOverride) {
 }
 
 export function getSpriteFrame(key) {
-  return spriteRegistry[key]?.frame ?? null;
+  if (!key) return null;
+  const normalizedKey = key === 'coin' ? 'gem' : key;
+  return spriteRegistry[normalizedKey]?.frame ?? null;
 }
 
 export const tileTextureDefinitions = textureRegistry;


### PR DESCRIPTION
## Summary
- add a gem collectible sprite descriptor alongside existing key, door, and checkpoint art
- map coin and gem sprite lookups to the gem art while keeping key requests intact
- normalize getSpriteFrame lookups so coin callers receive the gem frame

## Testing
- npm run test:smoke

------
https://chatgpt.com/codex/tasks/task_e_68e010865f5083279c0e65513be0b723