### PR TITLE
Add shared sprite strip loader and refactor sprite usage

### DIFF
--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -1,4 +1,5 @@
 import { Controls } from '../../src/runtime/controls.js';
+import { loadStrip } from '../../shared/assets.js';
 import { startSessionTimer, endSessionTimer } from '../../shared/metrics.js';
 import { emitEvent } from '../../shared/achievements.js';
 import { pushEvent } from '/games/common/diag-adapter.js';
@@ -915,18 +916,16 @@ class AsteroidsGame {
     if (!image) return;
     if (!this.isSpriteReady(image)) return;
 
-    const width = image.naturalWidth || image.width || 0;
-    const height = image.naturalHeight || image.height || 0;
-    if (!width || !height) return;
-
-    const frameSize = Math.min(width, height);
-    const framesPerRow = Math.max(1, Math.floor(width / frameSize));
-    const framesPerColumn = Math.max(1, Math.floor(height / frameSize));
-
-    this.portalSprite.frameWidth = frameSize;
-    this.portalSprite.frameHeight = frameSize;
-    this.portalSprite.framesPerRow = framesPerRow;
-    this.portalSprite.totalFrames = framesPerRow * framesPerColumn;
+    loadStrip('../../assets/effects/portal.png', this.portalSprite.frameWidth, this.portalSprite.frameHeight, {
+      slug: SLUG,
+      image,
+    }).then((strip) => {
+      this.images.portal = strip.image;
+      this.portalSprite.frameWidth = strip.frameWidth;
+      this.portalSprite.frameHeight = strip.frameHeight;
+      this.portalSprite.framesPerRow = strip.framesPerRow;
+      this.portalSprite.totalFrames = strip.frameCount;
+    }).catch(() => {});
   }
 
   prepareBulletVariants() {
@@ -941,15 +940,17 @@ class AsteroidsGame {
     if (!this.images?.explosion) return;
     if (!this.isSpriteReady(this.images.explosion)) return;
     const image = this.images.explosion;
-    const framesPerRow = 8;
-    const frameSize = Math.floor((image.naturalWidth || image.width) / framesPerRow) || 1;
-    const framesPerColumn = Math.max(
-      1,
-      Math.floor((image.naturalHeight || image.height) / frameSize),
-    );
-    this.explosionSprite.frameSize = frameSize;
-    this.explosionSprite.framesPerRow = framesPerRow;
-    this.explosionSprite.totalFrames = framesPerRow * framesPerColumn;
+    const framesPerRow = Math.max(1, this.explosionSprite.framesPerRow || 8);
+    loadStrip('../../assets/effects/explosion.png', this.explosionSprite.frameSize, this.explosionSprite.frameSize, {
+      slug: SLUG,
+      image,
+      framesPerRow,
+    }).then((strip) => {
+      this.images.explosion = strip.image;
+      this.explosionSprite.frameSize = strip.frameWidth;
+      this.explosionSprite.framesPerRow = strip.framesPerRow;
+      this.explosionSprite.totalFrames = strip.frameCount;
+    }).catch(() => {});
   }
 
   createShip() {

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1,6 +1,6 @@
 // Minimal top-down shooter (canvas id='game')
 import { pushEvent } from '/games/common/diag-adapter.js';
-import { getCachedAudio, getCachedImage, loadAudio, loadImage } from '../../shared/assets.js';
+import { getCachedAudio, getCachedImage, loadAudio, loadImage, loadStrip } from '../../shared/assets.js';
 import './diagnostics-adapter.js';
 
 export function boot() {
@@ -164,25 +164,34 @@ export function boot() {
   function prepareExplosionSprite() {
     const image = sprites.explosion;
     if (!isImageReady(image)) return;
-    const framesPerRow = explosionSprite.framesPerRow || 8;
-    const size = Math.floor((image.naturalWidth || image.width || 0) / framesPerRow) || 0;
-    if (!size) return;
-    const rows = Math.max(1, Math.floor((image.naturalHeight || image.height || 0) / size));
-    explosionSprite.frameSize = size;
-    explosionSprite.framesPerRow = framesPerRow;
-    explosionSprite.totalFrames = Math.max(1, framesPerRow * rows);
+    const framesPerRow = Math.max(1, explosionSprite.framesPerRow || 8);
+    loadStrip(ASSET_PATHS.explosion, explosionSprite.frameSize, explosionSprite.frameSize, {
+      slug: SLUG,
+      image,
+      framesPerRow,
+    }).then(strip => {
+      sprites.explosion = strip.image;
+      explosionSprite.frameSize = strip.frameWidth;
+      explosionSprite.framesPerRow = strip.framesPerRow;
+      explosionSprite.totalFrames = Math.max(1, strip.frameCount);
+    }).catch(() => {});
   }
 
   function preparePortalSprite() {
     const image = sprites.portal;
     if (!isImageReady(image)) return;
     const totalFrames = Math.max(1, portalSprite.totalFrames || 1);
-    const width = Math.floor((image.naturalWidth || image.width || 0) / totalFrames) || 0;
-    const height = image.naturalHeight || image.height || 0;
-    if (!width || !height) return;
-    portalSprite.frameWidth = width;
-    portalSprite.frameHeight = height;
-    portalSprite.totalFrames = totalFrames;
+    loadStrip(ASSET_PATHS.portal, portalSprite.frameWidth, portalSprite.frameHeight, {
+      slug: SLUG,
+      image,
+      framesPerRow: totalFrames,
+      totalFrames,
+    }).then(strip => {
+      sprites.portal = strip.image;
+      portalSprite.frameWidth = strip.frameWidth;
+      portalSprite.frameHeight = strip.frameHeight;
+      portalSprite.totalFrames = Math.max(1, strip.frameCount);
+    }).catch(() => {});
   }
 
   function createSoundPlayer(src, volume = 0.6) {


### PR DESCRIPTION
## Summary
- add a shared `loadStrip` helper that caches sprite sheet metadata on top of the existing image loader
- update the platformer player sprites to rely on the shared strip metadata instead of manual slicing
- refactor the Asteroids and Shooter effects to consume the shared strip loader when preparing animations

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e01ace9728832791a69798124fe382