### PR TITLE
Update fallback issue link to use repository slug

### DIFF
--- a/shared/fallback.js
+++ b/shared/fallback.js
@@ -1,4 +1,4 @@
-const REPO_SLUG = 'USER/Game';
+const REPO_SLUG = 'koonergurjot/Gurjots-Games';
 const ISSUE_BASE_URL = `https://github.com/${REPO_SLUG}/issues/new`;
 
 export function renderFallbackPanel(error, gameName) {


### PR DESCRIPTION
## Summary
- point the fallback panel's issue link at koonergurjot/Gurjots-Games
- verified the generated link still goes to the GitHub new issue page with prefilled context

## Testing
- node - <<'NODE'
const { JSDOM } = require('jsdom');
const { renderFallbackPanel } = require('./shared/fallback.js');

const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://koonergurjot.github.io/Gurjots-Games' });
Object.assign(global, {
  window: dom.window,
  document: dom.window.document,
  navigator: dom.window.navigator,
  location: dom.window.location,
  innerWidth: 1280,
  innerHeight: 720,
});

const error = new Error('Test failure');
renderFallbackPanel(error, 'Test Game');
const link = document.querySelector('#fallback-panel a');
console.log(link.href);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e3f726c7b48327907cfaabd5992eeb