### PR TITLE
Update Worker SPA fallback to 404 bootstrap page

### DIFF
--- a/cloudflare/worker.ts
+++ b/cloudflare/worker.ts
@@ -4,7 +4,7 @@ export interface Env {
   };
 }
 
-const SPA_FALLBACK_PATH = "/index.html";
+const SPA_FALLBACK_PATH = "/404.html";
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {


### PR DESCRIPTION
## Summary
- point the Worker SPA fallback path to `/404.html`, which bootstraps the SPA router
- confirmed the 404 handling branch continues to skip requests targeting assets with extensions before rewriting

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e43322412883279e19873fc225006a