### PR TITLE
Add redirect for game routes to SPA shell

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,12 @@
 
 [[headers]]
   for = "/*"
-  [headers.values]
+[headers.values]
     Access-Control-Allow-Origin = "*"
     Access-Control-Allow-Headers = "*"
+
+[[redirects]]
+  from = "/game/*"
+  to = "/404.html"
+  status = 200
+  force = true


### PR DESCRIPTION
## Summary
- add a Netlify redirect to serve the SPA shell for /game/* routes

## Testing
- npx netlify dev --help (fails: netlify CLI not installed)

------
https://chatgpt.com/codex/tasks/task_e_68e435e883f88327be3912f7f8cd7bae