### PR TITLE
Add asset preflight health indicator in game shell

### DIFF
--- a/game.html
+++ b/game.html
@@ -147,6 +147,10 @@
     .status p { margin:6px 0 0; color: var(--muted); }
     .row { display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }
     .pill { border:1px solid var(--border-strong); padding:6px 8px; border-radius:999px; font-size:12px; color:#cfe2ff; color:color-mix(in srgb, var(--fg, #e5f0ff) 70%, var(--muted) 30%); }
+    .pill[data-health="pending"] { border-color: rgba(148, 163, 184, 0.7); color: color-mix(in srgb, #e5f0ff 65%, #94a3b8 35%); }
+    .pill[data-health="good"] { border-color: rgba(34, 197, 94, 0.8); color: color-mix(in srgb, #bbf7d0 65%, #22c55e 35%); }
+    .pill[data-health="warn"] { border-color: rgba(250, 204, 21, 0.8); color: color-mix(in srgb, #fef3c7 60%, #f59e0b 40%); }
+    .pill[data-health="bad"] { border-color: rgba(248, 113, 113, 0.85); color: color-mix(in srgb, #fecaca 60%, #ef4444 40%); }
     .logbox {
       margin-top:10px; max-height:160px; overflow:auto; background: #0b1018;
       background: color-mix(in srgb, rgba(5,11,31,0.92) 40%, var(--card-solid) 60%);
@@ -328,6 +332,7 @@
               <span class="pill" id="pillSlug">slug: —</span>
               <span class="pill" id="pillTimer">t+0.0s</span>
               <span class="pill" id="pillSignal">signal: —</span>
+              <span class="pill" id="pillHealth">health: —</span>
             </div>
             <div class="actions" id="logActions">
               <button type="button" class="btn btn-ghost" id="btnCopyLogs">Copy logs</button>
@@ -368,6 +373,7 @@
       const pillSlug = document.getElementById("pillSlug");
       const pillTimer = document.getElementById("pillTimer");
       const pillSignal = document.getElementById("pillSignal");
+      const pillHealth = document.getElementById("pillHealth");
       const logbox = document.getElementById("logbox");
       const btnReload = document.getElementById("btnReload");
       const btnDiag = document.getElementById("btnDiag");
@@ -516,6 +522,143 @@
         logbox.scrollTop = logbox.scrollHeight;
       }
 
+      const assetExtPattern = /\.(?:js|css|png|jpe?g|webp|svg|json|mp3|wav|ogg)(?:[?#]|$)/i;
+      let assetPreflightStarted = false;
+
+      function setHealthPill(text, state) {
+        if (!pillHealth) return;
+        pillHealth.textContent = text;
+        if (state) {
+          pillHealth.dataset.health = state;
+        } else {
+          delete pillHealth.dataset.health;
+        }
+      }
+
+      function collectAssetUrls(html, baseUrl) {
+        try {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, "text/html");
+          const elements = doc.querySelectorAll("script[src], link[href], img[src], img[srcset], audio[src], video[src], source[src], source[srcset], track[src]");
+          const urls = new Set();
+
+          const tryAddUrl = (raw) => {
+            if (!raw) return;
+            try {
+              const url = new URL(raw, baseUrl);
+              if (assetExtPattern.test(url.pathname)) {
+                urls.add(url.href);
+              }
+            } catch (error) {
+              // Ignore malformed URLs
+            }
+          };
+
+          elements.forEach((el) => {
+            if (el.tagName === "LINK") {
+              tryAddUrl(el.getAttribute("href"));
+              return;
+            }
+
+            tryAddUrl(el.getAttribute("src"));
+
+            if (el.hasAttribute("srcset")) {
+              const srcset = el.getAttribute("srcset");
+              if (srcset) {
+                srcset.split(",").forEach((entry) => {
+                  const candidate = entry.trim().split(/\s+/)[0];
+                  tryAddUrl(candidate);
+                });
+              }
+            }
+          });
+          return Array.from(urls);
+        } catch (err) {
+          write("preflight parse error: " + (err && err.message ? err.message : err));
+          return [];
+        }
+      }
+
+      function headWithTimeout(url, timeoutMs) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), timeoutMs);
+        return fetch(url, { method: "HEAD", signal: controller.signal })
+          .then((resp) => resp.ok)
+          .catch(() => false)
+          .finally(() => clearTimeout(timeout));
+      }
+
+      function startAssetPreflight(wrapperUrl) {
+        if (assetPreflightStarted) return;
+        assetPreflightStarted = true;
+
+        if (!pillHealth) return;
+        if (!slug || !wrapperUrl) {
+          setHealthPill("health: n/a", "warn");
+          return;
+        }
+
+        const baseUrl = new URL(wrapperUrl, location.href);
+        setHealthPill("health: scanning…", "pending");
+
+        fetch(baseUrl.href)
+          .then((resp) => {
+            if (!resp.ok) {
+              throw new Error(`status ${resp.status}`);
+            }
+            return resp.text();
+          })
+          .then((html) => {
+            const assets = collectAssetUrls(html, baseUrl);
+            if (!assets.length) {
+              setHealthPill("health: 0/0 OK", "good");
+              write("preflight: 0/0 assets OK");
+              return;
+            }
+
+            let okCount = 0;
+            let failCount = 0;
+            let completed = 0;
+            const failures = [];
+
+            const updatePill = (final = false) => {
+              const text = `health: ${okCount}/${assets.length} OK`;
+              const state = final
+                ? (failCount === 0
+                  ? "good"
+                  : (failCount <= Math.max(1, Math.floor(assets.length * 0.3)) ? "warn" : "bad"))
+                : "pending";
+              setHealthPill(text, state);
+            };
+
+            updatePill(false);
+
+            const timeoutMs = 1500;
+            return Promise.allSettled(assets.map((url) => {
+              return headWithTimeout(url, timeoutMs).then((ok) => {
+                completed += 1;
+                if (ok) {
+                  okCount += 1;
+                } else {
+                  failCount += 1;
+                  failures.push(url);
+                }
+                updatePill(completed === assets.length);
+              });
+            })).then(() => {
+              updatePill(true);
+              write(`preflight: ${okCount}/${assets.length} assets OK`);
+              if (failures.length) {
+                failures.slice(0, 3).forEach((url) => write(`preflight fail: ${url}`));
+              }
+            });
+          })
+          .catch((err) => {
+            setHealthPill("health: wrapper fetch failed", "bad");
+            write("preflight skipped: " + (err && err.message ? err.message : err));
+          });
+      }
+
       // Wire buttons
       btnReload.addEventListener("click", () => {
         write("manual: reload requested");
@@ -545,6 +688,7 @@
           wireDiagButton();
         }
         write(`iframe src set → ${src}${note ? ` (${note})` : ""}`);
+        startAssetPreflight(src);
       }
 
       if (!slug) {


### PR DESCRIPTION
## Summary
- add a health pill to the shell status panel with color states for pending, warn, and failure
- introduce an asset preflight routine that fetches wrapper assets, issues timed HEAD requests, and reports progress via the new pill
- log preflight summaries and failures through the existing shell logging helper

## Testing
- python3 -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_68e43e150f3c832791dfe1cf55043423