### PR TITLE
Respect diagnostics monkeypatch opt-out flag

### DIFF
--- a/docs/diagnostics-migration.md
+++ b/docs/diagnostics-migration.md
@@ -65,3 +65,8 @@ shared queue until the shim takes over.
   custom panes.
 - `shared/diagnostics.js` will keep emitting a warning event until the module
   reference is removed.
+- Games that need to disable console/error/network hooks can set
+  `window.__DIAG_NO_MONKEYPATCH__ = true` **before** loading
+  `games/common/diag-capture.js`. The shim still reports basic environment
+  snapshots but skips monkey-patching `console`, `fetch`, `XMLHttpRequest` and
+  related listeners.

--- a/games/common/diag-capture.js
+++ b/games/common/diag-capture.js
@@ -5,6 +5,8 @@
   const global = typeof window !== "undefined" ? window : globalThis;
   if (!global) return;
 
+  const skipMonkeyPatch = !!(global.__DIAG_NO_MONKEYPATCH__ || global.__GG_DIAG_NO_MONKEYPATCH__);
+
   const queue = global.__GG_DIAG_QUEUE || (global.__GG_DIAG_QUEUE = []);
 
   function emit(entry){
@@ -409,15 +411,18 @@
     global.addEventListener("offline", () => emit({ category: "network", level: "warn", message: "navigator.online = false", timestamp: Date.now() }));
   }
 
-  installConsoleHooks();
-  installErrorHooks();
-  wrapFetch();
-  wrapXHR();
+  if (!skipMonkeyPatch) {
+    installConsoleHooks();
+    installErrorHooks();
+    wrapFetch();
+    wrapXHR();
+    installHeartbeat();
+    installNetworkListeners();
+  }
+
   reportCapabilities();
   reportPerformance();
   reportServiceWorker();
-  installHeartbeat();
-  installNetworkListeners();
 
   if (global) {
     global.__GG_DIAG_PUSH_EVENT__ = pushEvent;

--- a/tests/diag-capture.monkeypatch.test.js
+++ b/tests/diag-capture.monkeypatch.test.js
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const nativeNavigator = global.navigator;
+const nativeDocument = global.document;
+const nativePerformance = global.performance;
+
+describe('diag-capture opt-out flag', () => {
+  beforeEach(() => {
+    vi.resetModules();
+
+    const serviceWorkerRegistration = {
+      scope: '/test/',
+      active: { state: 'activated' },
+      installing: null,
+      waiting: null,
+    };
+
+    global.performance = {
+      now: () => 0,
+      getEntriesByType: () => [],
+      timing: {},
+      memory: null,
+    };
+
+    global.navigator = {
+      userAgent: 'test-agent',
+      language: 'en-US',
+      platform: 'test-platform',
+      hardwareConcurrency: 4,
+      deviceMemory: 2,
+      onLine: true,
+      serviceWorker: {
+        ready: Promise.resolve(serviceWorkerRegistration),
+        getRegistrations: () => Promise.resolve([serviceWorkerRegistration]),
+        controller: { state: 'activated' },
+      },
+    };
+
+    global.document = { visibilityState: 'visible' };
+    global.__GG_DIAG_QUEUE = [];
+  });
+
+  afterEach(() => {
+    if (nativePerformance === undefined) {
+      delete global.performance;
+    } else {
+      global.performance = nativePerformance;
+    }
+
+    if (nativeNavigator === undefined) {
+      delete global.navigator;
+    } else {
+      global.navigator = nativeNavigator;
+    }
+
+    if (nativeDocument === undefined) {
+      delete global.document;
+    } else {
+      global.document = nativeDocument;
+    }
+
+    delete global.__GG_DIAG_QUEUE;
+    delete global.__GG_DIAG;
+    delete global.__GG_DIAG_PUSH_EVENT__;
+    delete global.__DIAG_CAPTURE_READY;
+    delete global.__DIAG_NO_MONKEYPATCH__;
+  });
+
+  it('does not patch console or fetch when __DIAG_NO_MONKEYPATCH__ is truthy', async () => {
+    const originalConsoleLog = global.console?.log;
+    const originalConsoleError = global.console?.error;
+    const originalFetch = global.fetch;
+
+    global.__DIAG_NO_MONKEYPATCH__ = true;
+
+    await import('../games/common/diag-capture.js');
+
+    expect(global.console?.log).toBe(originalConsoleLog);
+    expect(global.console?.error).toBe(originalConsoleError);
+    expect(global.fetch).toBe(originalFetch);
+    expect(global.__DIAG_CAPTURE_READY).toBe(true);
+    expect(global.__GG_DIAG_PUSH_EVENT__).toBeTypeOf('function');
+  });
+});


### PR DESCRIPTION
## Summary
- guard the diagnostics capture shim with the __DIAG_NO_MONKEYPATCH__ flag before installing console/fetch/xhr hooks
- document the opt-out switch in the diagnostics migration guide
- add a regression test to ensure the shim respects the opt-out flag

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e440443394832795578fb34c6415bb