### PR TITLE
Scope diagnostics color scheme to overlay

### DIFF
--- a/games/common/diag-modal.css
+++ b/games/common/diag-modal.css
@@ -1,7 +1,3 @@
-:root {
-  color-scheme: dark;
-}
-
 body.gg-diag-scroll-locked {
   overflow: hidden;
 }
@@ -15,6 +11,7 @@ body.gg-diag-scroll-locked {
   inset: 0;
   pointer-events: none;
   z-index: 2147483599;
+  color-scheme: dark;
 }
 
 .diag-overlay .gg-diag-modal {


### PR DESCRIPTION
## Summary
- move the diagnostics modal dark color scheme declaration from the root to the overlay container
- ensure the dark theme applies only to the diagnostics UI and no longer affects the surrounding page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4424b0f048327b70af51185498c06