### PR TITLE
Add game doctor script to validate catalog assets

### DIFF
--- a/health/report.json
+++ b/health/report.json
@@ -1,0 +1,274 @@
+{
+  "generatedAt": "2025-10-06T22:32:21.773Z",
+  "summary": {
+    "total": 12,
+    "passing": 12,
+    "failing": 0
+  },
+  "games": [
+    {
+      "index": 0,
+      "title": "Pong Classic",
+      "slug": "pong",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/pong/index.html"
+      },
+      "assets": {
+        "sprites": [
+          "assets/sprites/paddle.png",
+          "assets/sprites/ball.png"
+        ],
+        "audio": [
+          "assets/audio/hit.wav",
+          "assets/audio/powerup.wav",
+          "assets/audio/click.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "games/pong/thumb.png"
+      }
+    },
+    {
+      "index": 1,
+      "title": "Snake",
+      "slug": "snake",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/snake/index.html"
+      },
+      "assets": {
+        "sprites": [
+          "assets/sprites/coin.png"
+        ],
+        "audio": [
+          "assets/audio/hit.wav",
+          "assets/audio/powerup.wav",
+          "assets/audio/click.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "assets/placeholder-thumb.png"
+      }
+    },
+    {
+      "index": 2,
+      "title": "Tetris",
+      "slug": "tetris",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/tetris/index.html"
+      },
+      "assets": {
+        "sprites": [
+          "assets/sprites/block.png",
+          "assets/backgrounds/arcade.png",
+          "assets/effects/spark.png",
+          "assets/effects/explosion.png"
+        ],
+        "audio": [
+          "assets/audio/hit.wav",
+          "assets/audio/powerup.wav",
+          "assets/audio/click.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "assets/placeholder-thumb.png"
+      }
+    },
+    {
+      "index": 3,
+      "title": "Breakout",
+      "slug": "breakout",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/breakout/index.html"
+      },
+      "assets": {
+        "sprites": [
+          "assets/sprites/paddle.png",
+          "assets/sprites/brick.png",
+          "assets/sprites/ball.png"
+        ],
+        "audio": [
+          "assets/audio/hit.wav",
+          "assets/audio/powerup.wav",
+          "assets/audio/click.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "assets/placeholder-thumb.png"
+      }
+    },
+    {
+      "index": 4,
+      "title": "Chess (2D)",
+      "slug": "chess",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/chess/index.html"
+      },
+      "assets": {
+        "sprites": [],
+        "audio": [
+          "assets/audio/click.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "assets/placeholder-thumb.png"
+      }
+    },
+    {
+      "index": 5,
+      "title": "Chess 3D (Local)",
+      "slug": "chess3d",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/chess3d/index.html"
+      },
+      "assets": {
+        "sprites": [],
+        "audio": [
+          "assets/audio/click.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "assets/placeholder-thumb.png"
+      }
+    },
+    {
+      "index": 6,
+      "title": "2048",
+      "slug": "2048",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/2048/index.html"
+      },
+      "assets": {
+        "sprites": [],
+        "audio": [
+          "assets/audio/click.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "assets/placeholder-thumb.png"
+      }
+    },
+    {
+      "index": 7,
+      "title": "Asteroids",
+      "slug": "asteroids",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/asteroids/index.html"
+      },
+      "assets": {
+        "sprites": [
+          "assets/sprites/ship.png"
+        ],
+        "audio": [
+          "assets/audio/hit.wav",
+          "assets/audio/explode.wav",
+          "assets/audio/powerup.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "games/asteroids/thumb.png"
+      }
+    },
+    {
+      "index": 8,
+      "title": "Maze 3D",
+      "slug": "maze3d",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/maze3d/index.html"
+      },
+      "assets": {
+        "sprites": [],
+        "audio": [
+          "assets/audio/powerup.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "games/maze3d/thumb.png"
+      }
+    },
+    {
+      "index": 9,
+      "title": "Pixel Platformer",
+      "slug": "platformer",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/platformer/index.html"
+      },
+      "assets": {
+        "sprites": [
+          "assets/sprites/coin.png"
+        ],
+        "audio": [
+          "assets/audio/hit.wav",
+          "assets/audio/powerup.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "games/platformer/thumb.png"
+      }
+    },
+    {
+      "index": 10,
+      "title": "City Runner",
+      "slug": "runner",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/runner/index.html"
+      },
+      "assets": {
+        "sprites": [
+          "assets/sprites/coin.png"
+        ],
+        "audio": [
+          "assets/audio/hit.wav",
+          "assets/audio/powerup.wav",
+          "assets/audio/click.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "games/runner/thumb.png"
+      }
+    },
+    {
+      "index": 11,
+      "title": "Alien Shooter",
+      "slug": "shooter",
+      "ok": true,
+      "issues": [],
+      "shell": {
+        "found": "games/shooter/index.html"
+      },
+      "assets": {
+        "sprites": [
+          "assets/sprites/ship.png"
+        ],
+        "audio": [
+          "assets/audio/explode.wav",
+          "assets/audio/powerup.wav"
+        ]
+      },
+      "thumbnail": {
+        "found": "games/shooter/thumb.png"
+      }
+    }
+  ]
+}

--- a/health/report.md
+++ b/health/report.md
@@ -1,0 +1,124 @@
+# Game Doctor Report
+
+Generated: 2025-10-06T22:32:21.773Z
+
+- Total games: 12
+- Passing: 12
+- Failing: 0
+
+## Pong Classic
+
+- Slug: pong
+- Status: ✅ Healthy
+- Shell: games/pong/index.html
+- Thumbnail: games/pong/thumb.png
+- Sprites checked: 2
+- Audio checked: 3
+- Issues: none
+
+## Snake
+
+- Slug: snake
+- Status: ✅ Healthy
+- Shell: games/snake/index.html
+- Thumbnail: assets/placeholder-thumb.png
+- Sprites checked: 1
+- Audio checked: 3
+- Issues: none
+
+## Tetris
+
+- Slug: tetris
+- Status: ✅ Healthy
+- Shell: games/tetris/index.html
+- Thumbnail: assets/placeholder-thumb.png
+- Sprites checked: 4
+- Audio checked: 3
+- Issues: none
+
+## Breakout
+
+- Slug: breakout
+- Status: ✅ Healthy
+- Shell: games/breakout/index.html
+- Thumbnail: assets/placeholder-thumb.png
+- Sprites checked: 3
+- Audio checked: 3
+- Issues: none
+
+## Chess (2D)
+
+- Slug: chess
+- Status: ✅ Healthy
+- Shell: games/chess/index.html
+- Thumbnail: assets/placeholder-thumb.png
+- Audio checked: 1
+- Issues: none
+
+## Chess 3D (Local)
+
+- Slug: chess3d
+- Status: ✅ Healthy
+- Shell: games/chess3d/index.html
+- Thumbnail: assets/placeholder-thumb.png
+- Audio checked: 1
+- Issues: none
+
+## 2048
+
+- Slug: 2048
+- Status: ✅ Healthy
+- Shell: games/2048/index.html
+- Thumbnail: assets/placeholder-thumb.png
+- Audio checked: 1
+- Issues: none
+
+## Asteroids
+
+- Slug: asteroids
+- Status: ✅ Healthy
+- Shell: games/asteroids/index.html
+- Thumbnail: games/asteroids/thumb.png
+- Sprites checked: 1
+- Audio checked: 3
+- Issues: none
+
+## Maze 3D
+
+- Slug: maze3d
+- Status: ✅ Healthy
+- Shell: games/maze3d/index.html
+- Thumbnail: games/maze3d/thumb.png
+- Audio checked: 1
+- Issues: none
+
+## Pixel Platformer
+
+- Slug: platformer
+- Status: ✅ Healthy
+- Shell: games/platformer/index.html
+- Thumbnail: games/platformer/thumb.png
+- Sprites checked: 1
+- Audio checked: 2
+- Issues: none
+
+## City Runner
+
+- Slug: runner
+- Status: ✅ Healthy
+- Shell: games/runner/index.html
+- Thumbnail: games/runner/thumb.png
+- Sprites checked: 1
+- Audio checked: 3
+- Issues: none
+
+## Alien Shooter
+
+- Slug: shooter
+- Status: ✅ Healthy
+- Shell: games/shooter/index.html
+- Thumbnail: games/shooter/thumb.png
+- Sprites checked: 1
+- Audio checked: 2
+- Issues: none
+

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:smoke": "vitest run tests/runner.smoke.test.js",
     "sitemap": "node tools/generate-sitemap.mjs",
     "health": "node tools/healthcheck.mjs",
+    "doctor": "node tools/game-doctor.mjs",
     "sync:games": "node tools/sync-game-catalog.mjs",
     "deploy": "npx wrangler deploy --config wrangler.toml",
     "deploy:check": "npx wrangler deploy --config wrangler.toml --dry-run"

--- a/tools/game-doctor.mjs
+++ b/tools/game-doctor.mjs
@@ -1,0 +1,278 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import process from 'process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const HEALTH_DIR = path.join(ROOT, 'health');
+const REPORT_JSON = path.join(HEALTH_DIR, 'report.json');
+const REPORT_MD = path.join(HEALTH_DIR, 'report.md');
+const PLACEHOLDER_THUMB = 'assets/placeholder-thumb.png';
+
+const gamesPath = path.join(ROOT, 'games.json');
+
+async function pathExists(candidate) {
+  try {
+    await fs.access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function deriveSlug(game) {
+  if (typeof game.slug === 'string' && game.slug.trim()) {
+    return game.slug.trim();
+  }
+  if (typeof game.id === 'string' && game.id.trim()) {
+    return game.id.trim();
+  }
+  if (typeof game.playUrl === 'string' && game.playUrl.trim()) {
+    const trimmed = game.playUrl.trim().replace(/\/+$/, '');
+    const parts = trimmed.split('/').filter(Boolean);
+    if (parts.length > 0) {
+      return parts[parts.length - 1];
+    }
+  }
+  return null;
+}
+
+function formatIssue(message, context = {}) {
+  return {
+    message,
+    context,
+  };
+}
+
+function ensureArray(value, label, issues) {
+  if (value == null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    issues.push(formatIssue(`${label} is not an array`, { received: value }));
+    return [];
+  }
+  return value;
+}
+
+function relativeFromRoot(filePath) {
+  return path.relative(ROOT, filePath).replace(/\\/g, '/');
+}
+
+function buildMarkdownReport(report) {
+  const lines = [];
+  lines.push('# Game Doctor Report');
+  lines.push('');
+  lines.push(`Generated: ${report.generatedAt}`);
+  lines.push('');
+  lines.push(`- Total games: ${report.summary.total}`);
+  lines.push(`- Passing: ${report.summary.passing}`);
+  lines.push(`- Failing: ${report.summary.failing}`);
+  lines.push('');
+  for (const game of report.games) {
+    lines.push(`## ${game.title ?? game.slug ?? 'Unknown Game'}`);
+    lines.push('');
+    lines.push(`- Slug: ${game.slug ?? 'N/A'}`);
+    lines.push(`- Status: ${game.ok ? '✅ Healthy' : '❌ Needs attention'}`);
+    if (game.shell?.found) {
+      lines.push(`- Shell: ${game.shell.found}`);
+    } else {
+      lines.push(`- Shell: missing`);
+    }
+    lines.push(`- Thumbnail: ${game.thumbnail?.found ?? 'missing'}`);
+    if (game.assets?.sprites?.length) {
+      lines.push(`- Sprites checked: ${game.assets.sprites.length}`);
+    }
+    if (game.assets?.audio?.length) {
+      lines.push(`- Audio checked: ${game.assets.audio.length}`);
+    }
+    if (game.issues.length === 0) {
+      lines.push('- Issues: none');
+    } else {
+      lines.push('- Issues:');
+      for (const issue of game.issues) {
+        lines.push(`  - ${issue.message}`);
+        const entries = Object.entries(issue.context ?? {});
+        if (entries.length) {
+          for (const [key, value] of entries) {
+            lines.push(`    - ${key}: ${JSON.stringify(value)}`);
+          }
+        }
+      }
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+async function main() {
+  if (!(await pathExists(gamesPath))) {
+    console.error(`Unable to locate games catalog at ${relativeFromRoot(gamesPath)}.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const raw = await fs.readFile(gamesPath, 'utf8');
+  let games;
+  try {
+    games = JSON.parse(raw);
+  } catch (error) {
+    console.error('Failed to parse games.json:', error);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!Array.isArray(games)) {
+    console.error('Expected games.json to contain an array of games.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const results = [];
+
+  for (const [index, game] of games.entries()) {
+    const issues = [];
+
+    const slug = deriveSlug(game);
+    if (!slug) {
+      issues.push(formatIssue('Unable to determine slug for game entry', { index }));
+    }
+
+    const title = typeof game.title === 'string' ? game.title : `Game #${index + 1}`;
+
+    let foundShell = null;
+    if (slug) {
+      const shellCandidates = [
+        path.join(ROOT, 'games', slug, 'index.html'),
+        path.join(ROOT, 'gameshells', slug, 'index.html'),
+      ];
+
+      for (const candidate of shellCandidates) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await pathExists(candidate)) {
+          foundShell = relativeFromRoot(candidate);
+          break;
+        }
+      }
+
+      if (!foundShell) {
+        issues.push(
+          formatIssue('Missing playable shell', {
+            tried: shellCandidates.map(relativeFromRoot),
+          }),
+        );
+      }
+    }
+
+    const firstFrame = game.firstFrame ?? {};
+    const spriteList = ensureArray(firstFrame.sprites, 'firstFrame.sprites', issues);
+    const audioList = ensureArray(firstFrame.audio, 'firstFrame.audio', issues);
+
+    const checkedSprites = [];
+    for (const sprite of spriteList) {
+      if (typeof sprite !== 'string' || !sprite.trim()) {
+        issues.push(formatIssue('Sprite asset is not a valid path', { sprite }));
+        continue;
+      }
+      if (!sprite.startsWith('/assets/')) {
+        issues.push(formatIssue('Sprite asset must live under /assets/', { sprite }));
+        continue;
+      }
+      const spritePath = path.join(ROOT, sprite.replace(/^\//, ''));
+      // eslint-disable-next-line no-await-in-loop
+      if (!(await pathExists(spritePath))) {
+        issues.push(formatIssue('Sprite asset missing on disk', { sprite, expected: relativeFromRoot(spritePath) }));
+        continue;
+      }
+      checkedSprites.push(relativeFromRoot(spritePath));
+    }
+
+    const checkedAudio = [];
+    for (const audio of audioList) {
+      if (typeof audio !== 'string' || !audio.trim()) {
+        issues.push(formatIssue('Audio asset is not a valid path', { audio }));
+        continue;
+      }
+      if (!audio.startsWith('/assets/')) {
+        issues.push(formatIssue('Audio asset must live under /assets/', { audio }));
+        continue;
+      }
+      const audioPath = path.join(ROOT, audio.replace(/^\//, ''));
+      // eslint-disable-next-line no-await-in-loop
+      if (!(await pathExists(audioPath))) {
+        issues.push(formatIssue('Audio asset missing on disk', { audio, expected: relativeFromRoot(audioPath) }));
+        continue;
+      }
+      checkedAudio.push(relativeFromRoot(audioPath));
+    }
+
+    let thumbnailFound = null;
+    if (slug) {
+      const thumbCandidates = [
+        path.join(ROOT, 'assets', 'thumbs', `${slug}.png`),
+        path.join(ROOT, 'games', slug, 'thumb.png'),
+        path.join(ROOT, PLACEHOLDER_THUMB),
+      ];
+      for (const candidate of thumbCandidates) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await pathExists(candidate)) {
+          thumbnailFound = relativeFromRoot(candidate);
+          break;
+        }
+      }
+      if (!thumbnailFound) {
+        issues.push(
+          formatIssue('Thumbnail missing', {
+            tried: thumbCandidates.map(relativeFromRoot),
+          }),
+        );
+      }
+    }
+
+    const result = {
+      index,
+      title,
+      slug,
+      ok: issues.length === 0,
+      issues,
+      shell: { found: foundShell },
+      assets: {
+        sprites: checkedSprites,
+        audio: checkedAudio,
+      },
+      thumbnail: { found: thumbnailFound },
+    };
+
+    results.push(result);
+  }
+
+  const summary = {
+    total: results.length,
+    passing: results.filter((game) => game.ok).length,
+    failing: results.filter((game) => !game.ok).length,
+  };
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    summary,
+    games: results,
+  };
+
+  await fs.mkdir(HEALTH_DIR, { recursive: true });
+  await fs.writeFile(REPORT_JSON, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  await fs.writeFile(REPORT_MD, `${buildMarkdownReport(report)}\n`, 'utf8');
+
+  if (summary.failing > 0) {
+    console.error(
+      `Game doctor found ${summary.failing} of ${summary.total} game(s) with issues. See ${relativeFromRoot(
+        REPORT_JSON,
+      )} for details.`,
+    );
+    process.exitCode = 1;
+  } else {
+    console.log(`Game doctor: all ${summary.total} game(s) look healthy!`);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a doctor script that validates every game entry in games.json and checks for shells, assets, and thumbnails
- emit structured (JSON) and human-readable (Markdown) health reports under the health/ directory
- expose an npm doctor script to run the validator locally

## Testing
- npm run doctor

------
https://chatgpt.com/codex/tasks/task_e_68e443381a088327be3bb8aaecdfb96a