### PR TITLE
Add Game Doctor CI workflow

### DIFF
--- a/.github/workflows/game-doctor.yml
+++ b/.github/workflows/game-doctor.yml
@@ -1,0 +1,36 @@
+name: Game Doctor
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    name: Run Game Doctor
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Game Doctor
+        run: node tools/game-doctor.mjs
+
+      - name: Upload Game Doctor report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: game-doctor-report
+          if-no-files-found: ignore
+          path: |
+            health/report.json
+            health/report.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,13 @@ npm run health       # verifies game metadata and assets
 npm test             # runs the test suite
 ```
 
+## Game Doctor continuous integration check
+
+Every push and pull request triggers the **Game Doctor** GitHub Action, which runs `node tools/game-doctor.mjs` and fails the
+check when any game needs attention. If you need to re-run the check, open your pull request, switch to the **Checks** tab,
+select **Game Doctor**, and click **Re-run**. The workflow uploads `health/report.json` and `health/report.md` as artifacts;
+download them from the same check summary to review the full report.
+
 ## Common errors & quick fixes
 
 - **Game never cleans up resources** – Ensure `dispose()` removes listeners and stops loops.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the Game Doctor script on pushes and pull requests
- upload the generated Game Doctor health reports as workflow artifacts
- document how to rerun the Game Doctor check and download its report

## Testing
- not run (CI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e443fc5540832795e43786aa379d74