### PR TITLE
Allow diagnostics button suppression

### DIFF
--- a/games/common/diag-core.js
+++ b/games/common/diag-core.js
@@ -9,7 +9,7 @@
   }
 
   const existingQueue = Array.isArray(global.__GG_DIAG_QUEUE) ? global.__GG_DIAG_QUEUE.splice(0) : [];
-  global.__GG_DIAG_OPTS = Object.assign({}, { suppressButton: true }, global.__GG_DIAG_OPTS || {});
+  global.__GG_DIAG_OPTS = Object.assign({}, { suppressButton: false }, global.__GG_DIAG_OPTS || {});
 
   const reportStoreModule = ensureReportStoreModule();
   const reportStore = reportStoreModule.createReportStore({
@@ -483,14 +483,19 @@
     root.dataset.ggDiagRoot = "modern";
     root.className = "diag-overlay";
 
-    const fab = doc.createElement("button");
-    fab.type = "button";
-    fab.className = "gg-diag-fab";
-    fab.setAttribute("aria-label", "Open diagnostics console");
-    fab.setAttribute("aria-haspopup", "dialog");
-    fab.setAttribute("aria-expanded", "false");
-    fab.innerHTML = "&#9881;";
-    fab.addEventListener("click", () => open());
+    const suppressButton = !!global.__GG_DIAG_OPTS?.suppressButton;
+
+    let fab = null;
+    if (!suppressButton) {
+      fab = doc.createElement("button");
+      fab.type = "button";
+      fab.className = "gg-diag-fab";
+      fab.setAttribute("aria-label", "Open diagnostics console");
+      fab.setAttribute("aria-haspopup", "dialog");
+      fab.setAttribute("aria-expanded", "false");
+      fab.innerHTML = "&#9881;";
+      fab.addEventListener("click", () => open());
+    }
 
     const backdrop = doc.createElement("div");
     backdrop.className = "gg-diag-backdrop";
@@ -616,7 +621,11 @@
     modal.append(header, body, actions);
     backdrop.append(modal);
     root.append(backdrop);
-    doc.body.append(root, fab);
+    if (fab) {
+      doc.body.append(root, fab);
+    } else {
+      doc.body.append(root);
+    }
 
     state.root = root;
     state.fab = fab;

--- a/games/common/diagnostics/README.md
+++ b/games/common/diagnostics/README.md
@@ -5,6 +5,11 @@ Per-game diagnostics adapters allow a title to integrate with the shared
 overlay can react to what the game is doing) and optional control APIs (so
 QA can poke at the running game directly from diagnostics tools).
 
+Hosts can customise the overlay bootstrap through `window.__GG_DIAG_OPTS`.
+Setting `suppressButton: true` prevents the floating diagnostics button
+from being injected so an embedding shell can expose its own trigger while
+still opening the modal via `window.__GG_DIAG.open()`.
+
 ## Registering an adapter
 
 Use `registerGameDiagnostics(slug, adapter)` from


### PR DESCRIPTION
## Summary
- respect `window.__GG_DIAG_OPTS.suppressButton` when building the diagnostics UI so hosts can hide the floating button
- document the host option for suppressing the default trigger

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4449371a0832796bb6f073adc854e