### PR TITLE
Add manifest-driven asset verification to game doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ Visit [localhost:3000](http://localhost:3000) to play!
 - [Contributing Guide](CONTRIBUTING.md)
 - [FAQ](#-faq)
 
+### 🩺 Game Doctor Manifest
+
+The automated health check looks for extra assets defined in
+`tools/reporters/game-doctor-manifest.json`. Each game slug can list
+required files (via the `paths` array) and file patterns (via the `globs`
+array). All values are resolved relative to the folder that contains the
+playable shell (`index.html`).
+
+```json
+{
+  "requirements": {
+    "pong": {
+      "paths": ["manifest.json", "pong.css"],
+      "globs": ["*.js"]
+    }
+  }
+}
+```
+
+To add new asset requirements:
+
+1. Identify the slug and shell folder for the game you are updating.
+2. Add (or update) the corresponding entry in the manifest with the files
+   or glob patterns that must exist beside the shell.
+3. Keep requirements in arrays of strings—invalid entries will be treated
+   as manifest errors during the health check.
+4. Run `node tools/game-doctor.mjs` (or `npm run doctor`) to confirm the
+   manifest changes pass.
+
 ---
 
 ## ❓ FAQ

--- a/health/report.json
+++ b/health/report.json
@@ -1,9 +1,13 @@
 {
-  "generatedAt": "2025-10-06T22:41:37.883Z",
+  "generatedAt": "2025-10-06T22:49:41.382Z",
   "summary": {
     "total": 12,
     "passing": 12,
     "failing": 0
+  },
+  "manifest": {
+    "version": 1,
+    "source": "tools/reporters/game-doctor-manifest.json"
   },
   "games": [
     {
@@ -28,6 +32,47 @@
       },
       "thumbnail": {
         "found": "games/pong/thumb.png"
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "manifest.json",
+            "found": true,
+            "resolved": "games/pong/manifest.json"
+          },
+          {
+            "requirement": "pong.css",
+            "found": true,
+            "resolved": "games/pong/pong.css"
+          }
+        ],
+        "globs": [
+          {
+            "pattern": "*.js",
+            "matches": [
+              {
+                "relativeToShell": "adapter.js",
+                "relativeToRoot": "games/pong/adapter.js"
+              },
+              {
+                "relativeToShell": "career.js",
+                "relativeToRoot": "games/pong/career.js"
+              },
+              {
+                "relativeToShell": "main.js",
+                "relativeToRoot": "games/pong/main.js"
+              },
+              {
+                "relativeToShell": "pauseOverlay.js",
+                "relativeToRoot": "games/pong/pauseOverlay.js"
+              },
+              {
+                "relativeToShell": "pong.js",
+                "relativeToRoot": "games/pong/pong.js"
+              }
+            ]
+          }
+        ]
       }
     },
     {
@@ -223,6 +268,35 @@
       },
       "thumbnail": {
         "found": "games/platformer/thumb.png"
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "levels",
+            "found": true,
+            "resolved": "games/platformer/levels"
+          },
+          {
+            "requirement": "tiles.js",
+            "found": true,
+            "resolved": "games/platformer/tiles.js"
+          }
+        ],
+        "globs": [
+          {
+            "pattern": "levels/*.json",
+            "matches": [
+              {
+                "relativeToShell": "levels/level1.json",
+                "relativeToRoot": "games/platformer/levels/level1.json"
+              },
+              {
+                "relativeToShell": "levels/level2.json",
+                "relativeToRoot": "games/platformer/levels/level2.json"
+              }
+            ]
+          }
+        ]
       }
     },
     {

--- a/health/report.md
+++ b/health/report.md
@@ -1,10 +1,12 @@
 # Game Doctor Report
 
-Generated: 2025-10-06T22:41:37.883Z
+Generated: 2025-10-06T22:49:41.382Z
 
 - Total games: 12
 - Passing: 12
 - Failing: 0
+- Manifest version: 1
+- Manifest source: tools/reporters/game-doctor-manifest.json
 
 ## Pong Classic
 
@@ -14,6 +16,8 @@ Generated: 2025-10-06T22:41:37.883Z
 - Thumbnail: games/pong/thumb.png
 - Sprites checked: 2
 - Audio checked: 3
+- Manifest paths: all required paths found
+- Manifest globs: all patterns matched files
 - Issues: none
 
 ## Snake
@@ -100,6 +104,8 @@ Generated: 2025-10-06T22:41:37.883Z
 - Thumbnail: games/platformer/thumb.png
 - Sprites checked: 1
 - Audio checked: 2
+- Manifest paths: all required paths found
+- Manifest globs: all patterns matched files
 - Issues: none
 
 ## City Runner

--- a/tools/reporters/game-doctor-manifest.json
+++ b/tools/reporters/game-doctor-manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "notes": "Paths and glob patterns are relative to the folder containing the playable shell (index.html).",
+  "requirements": {
+    "pong": {
+      "paths": [
+        "manifest.json",
+        "pong.css"
+      ],
+      "globs": [
+        "*.js"
+      ]
+    },
+    "platformer": {
+      "paths": [
+        "levels",
+        "tiles.js"
+      ],
+      "globs": [
+        "levels/*.json"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a manifest that lists per-slug asset requirements for the game doctor
- load the manifest during the health check to validate required files and glob patterns near each shell and surface any problems in the reports
- document how to extend the manifest and refresh the generated health report outputs

## Testing
- node tools/game-doctor.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e4463b67a08327bf6ce579ede80f78