### PR TITLE
Guard diag autowire against duplicate capture injection

### DIFF
--- a/games/common/diag-autowire.js
+++ b/games/common/diag-autowire.js
@@ -7,6 +7,8 @@
   const alreadyInitialized = () => {
     const g = win.__GG_DIAG;
     if (g && (g.initialized || g.ready || g.core || g.loaded)) return true;
+    if (g && typeof g.log === 'function') return true;
+    if (win.__DIAG_CAPTURE_READY) return true;
     try {
       if (doc.querySelector('script[data-gg-diag-core],script[data-gg-diag-capture],script[src*="diag-core"],script[src*="diag-capture"]')) {
         return true;
@@ -172,6 +174,9 @@
 
     ensureScript(buildRootUrl('/games/common/diagnostics/report-store.js'), 'data-gg-diag-report');
     ensureScript(buildRootUrl('/games/common/diag-core.js'), 'data-gg-diag-core');
-    ensureScript(buildRootUrl('/games/common/diag-capture.js'), 'data-gg-diag-capture');
+    const captureActive = !!(win.__DIAG_CAPTURE_READY || (win.__GG_DIAG && typeof win.__GG_DIAG.log === 'function'));
+    if (!captureActive) {
+      ensureScript(buildRootUrl('/games/common/diag-capture.js'), 'data-gg-diag-capture');
+    }
   });
 })();

--- a/tests/diag-autowire.capture-guard.test.js
+++ b/tests/diag-autowire.capture-guard.test.js
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const nativeWindow = global.window;
+const nativeDocument = global.document;
+
+describe('diag-autowire guard', () => {
+  let dom;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    dom = new JSDOM('<!doctype html><html><head></head><body></body></html>', { url: 'https://example.com/' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.window.__GG_DIAG = { log: () => {} };
+    const marker = dom.window.document.createElement('script');
+    marker.id = 'gg-diag-autowire';
+    dom.window.document.head.appendChild(marker);
+    await import('../games/common/diag-autowire.js');
+  });
+
+  afterEach(() => {
+    if (nativeWindow === undefined) {
+      delete global.window;
+    } else {
+      global.window = nativeWindow;
+    }
+
+    if (nativeDocument === undefined) {
+      delete global.document;
+    } else {
+      global.document = nativeDocument;
+    }
+
+    if (dom) {
+      dom.window.close();
+      dom = null;
+    }
+  });
+
+  it('does not append diag-capture when diagnostics are already active', () => {
+    const scripts = dom.window.document.querySelectorAll('script[data-gg-diag-capture]');
+    expect(scripts.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- treat existing diagnostic sessions as initialized when a log helper or capture-ready flag is present
- avoid reinjecting the capture script once diagnostics are active to prevent duplicate monkeypatches
- add a regression test that confirms no capture script is appended when diagnostics are already live

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e44834e98c8327a7369106ef3cd682