### PR TITLE
Add ZIP preview support to admin import cards

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -3,7 +3,7 @@
 <title>Admin — Gurjot's Games</title>
 <link rel="stylesheet" href="../css/styles.css"/>
 <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
-<style>body{padding:18px}.row{display:flex;gap:16px;align-items:center;flex-wrap:wrap}textarea{width:100%;height:46vh;border-radius:12px;background:var(--bg-soft);color:var(--text);border:1px solid var(--card-border);padding:12px;font-family:ui-monospace,menlo,consolas}.drop{padding:18px;border:2px dashed var(--card-border);border-radius:12px;text-align:center;margin:14px 0}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;margin:10px 0}.mini{background:var(--bg-soft);border:1px solid var(--card-border);border-radius:12px;padding:10px}.mini h4{margin:4px 0 6px}.pill{font-size:.8rem;padding:4px 8px;border-radius:999px;border:1px solid var(--card-border);background:var(--chip);color:var(--text)}.hide{display:none}.editor-shell{display:flex;flex-wrap:wrap;gap:18px;margin-top:16px}.editor-shell aside,.editor-shell section,.editor-shell .json-pane{flex:1 1 280px;min-width:260px}.editor-shell aside{max-width:320px;background:var(--bg-soft);border:1px solid var(--card-border);border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:12px}.editor-shell aside header{display:flex;justify-content:space-between;align-items:center;gap:8px}.editor-shell aside h3{margin:0;font-size:1rem}.editor-shell aside .list{display:flex;flex-direction:column;gap:6px;overflow-y:auto;max-height:46vh;padding-right:4px}.game-row{border:1px solid var(--card-border);border-radius:10px;padding:10px;cursor:pointer;background:var(--bg-soft);display:flex;flex-direction:column;gap:8px;transition:border-color .15s,background .15s}.game-row:hover{border-color:var(--primary)}.game-row.selected{border-color:var(--primary);background:rgba(132,90,223,0.12)}.game-row .meta{display:flex;flex-wrap:wrap;gap:6px;font-size:.75rem}.badge{padding:2px 8px;border-radius:999px;background:var(--chip);border:1px solid var(--card-border);text-transform:uppercase;letter-spacing:.05em}.editor-shell section{border:1px solid var(--card-border);border-radius:12px;padding:16px;background:var(--bg-soft);min-height:46vh}.editor-shell section h3{margin-top:0}.editor-shell section form{display:flex;flex-direction:column;gap:12px}.editor-shell section label{font-weight:600;display:block;margin-bottom:6px}.editor-shell section input[type="text"],.editor-shell section textarea{width:100%;padding:10px;border-radius:8px;border:1px solid var(--card-border);background:var(--bg);color:var(--text);font-family:inherit}.editor-shell section textarea{min-height:120px;font-family:inherit}.flag-grid{display:flex;flex-wrap:wrap;gap:10px}.flag-grid label{font-weight:400;display:flex;align-items:center;gap:6px}.json-pane label{font-weight:600;display:block;margin-bottom:8px}.json-pane textarea{height:46vh}</style>
+<style>body{padding:18px}.row{display:flex;gap:16px;align-items:center;flex-wrap:wrap}textarea{width:100%;height:46vh;border-radius:12px;background:var(--bg-soft);color:var(--text);border:1px solid var(--card-border);padding:12px;font-family:ui-monospace,menlo,consolas}.drop{padding:18px;border:2px dashed var(--card-border);border-radius:12px;text-align:center;margin:14px 0}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;margin:10px 0}.mini{background:var(--bg-soft);border:1px solid var(--card-border);border-radius:12px;padding:10px}.mini h4{margin:4px 0 6px}.pill{font-size:.8rem;padding:4px 8px;border-radius:999px;border:1px solid var(--card-border);background:var(--chip);color:var(--text)}.hide{display:none}.import-actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px}.import-actions small{flex:1;opacity:.8}.preview-shell{display:none;margin-top:10px;border:1px solid var(--card-border);border-radius:10px;overflow:hidden;position:relative;background:var(--bg);min-height:210px;box-shadow:0 10px 30px rgba(0,0,0,0.18)}.preview-shell.active{display:block}.preview-shell iframe{width:100%;height:210px;border:0;background:#000}.preview-shell .preview-close{position:absolute;top:8px;right:8px;z-index:2;padding:6px 10px;font-size:.85rem}.preview-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:.9rem;background:linear-gradient(135deg,rgba(132,90,223,0.12),rgba(132,90,223,0.04));color:var(--text-muted,#9ba0b8);text-align:center;padding:12px}.preview-shell:not(.active) .preview-placeholder{display:none}.editor-shell{display:flex;flex-wrap:wrap;gap:18px;margin-top:16px}.editor-shell aside,.editor-shell section,.editor-shell .json-pane{flex:1 1 280px;min-width:260px}.editor-shell aside{max-width:320px;background:var(--bg-soft);border:1px solid var(--card-border);border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:12px}.editor-shell aside header{display:flex;justify-content:space-between;align-items:center;gap:8px}.editor-shell aside h3{margin:0;font-size:1rem}.editor-shell aside .list{display:flex;flex-direction:column;gap:6px;overflow-y:auto;max-height:46vh;padding-right:4px}.game-row{border:1px solid var(--card-border);border-radius:10px;padding:10px;cursor:pointer;background:var(--bg-soft);display:flex;flex-direction:column;gap:8px;transition:border-color .15s,background .15s}.game-row:hover{border-color:var(--primary)}.game-row.selected{border-color:var(--primary);background:rgba(132,90,223,0.12)}.game-row .meta{display:flex;flex-wrap:wrap;gap:6px;font-size:.75rem}.badge{padding:2px 8px;border-radius:999px;background:var(--chip);border:1px solid var(--card-border);text-transform:uppercase;letter-spacing:.05em}.editor-shell section{border:1px solid var(--card-border);border-radius:12px;padding:16px;background:var(--bg-soft);min-height:46vh}.editor-shell section h3{margin-top:0}.editor-shell section form{display:flex;flex-direction:column;gap:12px}.editor-shell section label{font-weight:600;display:block;margin-bottom:6px}.editor-shell section input[type="text"],.editor-shell section textarea{width:100%;padding:10px;border-radius:8px;border:1px solid var(--card-border);background:var(--bg);color:var(--text);font-family:inherit}.editor-shell section textarea{min-height:120px;font-family:inherit}.flag-grid{display:flex;flex-wrap:wrap;gap:10px}.flag-grid label{font-weight:400;display:flex;align-items:center;gap:6px}.json-pane label{font-weight:600;display:block;margin-bottom:8px}.json-pane textarea{height:46vh}</style>
 </head>
 <body>
 <h2>Admin / CMS</h2>
@@ -32,6 +32,12 @@
 <div class="grid" id="imports"></div>
 <script>
 const ed=document.getElementById('editor');const imports=document.getElementById('imports');const gameList=document.getElementById('gameList');const editorPanel=document.getElementById('gameEditor');let pendingAdds=[];let games=[];let selectedIndex=null;let syncingTextarea=false;const flagFields=['new','beta','featured','hidden','unlisted'];
+const ABSOLUTE_PATTERN=/^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i;
+function resolveZipPath(path,prefix){const base=(prefix||'');try{const normalized=new URL(path,'https://preview/'+base+'index.html');const pathname=decodeURIComponent(normalized.pathname.replace(/^\//,''));return{path:pathname,search:normalized.search||'',hash:normalized.hash||''}}catch{return{path:(base+path).replace(/^\//,''),search:'',hash:''}}}
+function isSkippableResource(val){return !val||ABSOLUTE_PATTERN.test(val.trim())||/^data:/i.test(val.trim())}
+async function createBlobUrl(record,val,state,token){if(state.token!==token)return null;const {path,search,hash}=resolveZipPath(val,record.prefix);let file=record.zip.file(path);if(!file&&record.prefix&&path.startsWith(record.prefix)){file=record.zip.file(path.slice(record.prefix.length))}if(!file&&record.prefix){const fallback=(record.prefix.replace(/\/?$/,'/')+val).replace(/^\//,'');file=record.zip.file(fallback)}if(!file||state.token!==token)return null;const blob=await file.async('blob');if(state.token!==token)return null;const url=URL.createObjectURL(blob);state.urls.push(url);return url+search+hash}
+async function rewriteSrcset(record,el,state,token){if(state.token!==token)return;const raw=el.getAttribute('srcset');if(!raw)return;const parts=raw.split(',');const next=[];for(const part of parts){const trimmed=part.trim();if(!trimmed)continue;const segments=trimmed.split(/\s+/);const ref=segments.shift();if(!ref)continue;if(isSkippableResource(ref)){next.push(trimmed);continue}const blobUrl=await createBlobUrl(record,ref,state,token);if(state.token!==token)return;if(blobUrl)next.push([blobUrl,...segments].join(' '))}if(next.length)el.setAttribute('srcset',next.join(', '))}
+async function loadPreviewIntoFrame(record,frame,state,placeholder,token){state.cleanup();if(state.token!==token)return;const htmlFile=record.zip.file(record.prefix+'index.html')||record.zip.file('index.html');if(!htmlFile)throw new Error('index.html missing');const htmlText=await htmlFile.async('string');if(state.token!==token){state.cleanup();return}const parser=new DOMParser();const doc=parser.parseFromString(htmlText,'text/html');const selectors=[[doc.querySelectorAll('[src]'),'src'],[doc.querySelectorAll('link[href]'),'href'],[doc.querySelectorAll('[poster]'),'poster'],[doc.querySelectorAll('object[data]'),'data']];for(const [nodeList,attr] of selectors){for(const el of nodeList){if(state.token!==token){state.cleanup();return}if(!el||!el.getAttribute)continue;const raw=el.getAttribute(attr);if(isSkippableResource(raw))continue;if(attr==='href'&&el.tagName==='A')continue;const blobUrl=await createBlobUrl(record,raw,state,token);if(state.token!==token){state.cleanup();return}if(blobUrl)el.setAttribute(attr,blobUrl)}}const svgUses=[...doc.querySelectorAll('[xlink\\:href]')];for(const el of svgUses){if(state.token!==token){state.cleanup();return}const raw=el.getAttribute('xlink:href');if(isSkippableResource(raw))continue;const blobUrl=await createBlobUrl(record,raw,state,token);if(state.token!==token){state.cleanup();return}if(blobUrl)el.setAttribute('xlink:href',blobUrl)}const srcsetEls=[...doc.querySelectorAll('img[srcset],source[srcset]')];for(const el of srcsetEls){if(state.token!==token){state.cleanup();return}await rewriteSrcset(record,el,state,token)}if(state.token!==token){state.cleanup();return}frame.srcdoc='<!doctype html>'+doc.documentElement.outerHTML;placeholder.hidden=true}
 const escapeHTML=str=>String(str??'').replace(/[&<>"']/g,s=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[s]));
 function syncTextarea(){syncingTextarea=true;ed.value=JSON.stringify(games,null,2);syncingTextarea=false}
 function renderList(){gameList.innerHTML='';const header=document.createElement('header');const title=document.createElement('h3');title.textContent='Games';header.appendChild(title);const btnWrap=document.createElement('div');btnWrap.className='row';btnWrap.style.margin='0';btnWrap.style.gap='8px';const addBtn=document.createElement('button');addBtn.id='addGame';addBtn.className='btn';addBtn.type='button';addBtn.textContent='Add game';addBtn.onclick=()=>{const stamp=Date.now();let baseId='new-game-'+stamp;let inc=1;while(games.some(g=>g.id===baseId)){baseId='new-game-'+(stamp+inc++);}const newGame={id:baseId,title:'New Game',path:`games/${baseId}/index.html`,description:'',tags:[],emoji:'🎮',new:true,addedAt:new Date().toISOString().slice(0,10)};games=[...games,newGame];selectedIndex=games.length-1;renderList();renderEditor();syncTextarea();};const dupBtn=document.createElement('button');dupBtn.id='duplicateGame';dupBtn.className='btn';dupBtn.type='button';dupBtn.textContent='Duplicate game';dupBtn.onclick=()=>{if(selectedIndex===null){alert('Select a game to duplicate first.');return}const base=games[selectedIndex];const clone=JSON.parse(JSON.stringify(base));let baseId=base.id+'-copy';let inc=1;while(games.some(g=>g.id===baseId)){baseId=base.id+'-copy'+inc++;}clone.id=baseId;clone.path=base.path.replace(base.id,clone.id);clone.addedAt=new Date().toISOString().slice(0,10);games=[...games,clone];selectedIndex=games.length-1;renderList();renderEditor();syncTextarea();};btnWrap.appendChild(addBtn);btnWrap.appendChild(dupBtn);header.appendChild(btnWrap);gameList.appendChild(header);const list=document.createElement('div');list.className='list';if(!games.length){const empty=document.createElement('p');empty.textContent='Load a JSON file to see games.';empty.style.margin='12px 0 0';empty.style.opacity='0.8';gameList.appendChild(empty)}games.forEach((game,idx)=>{const row=document.createElement('div');row.className='game-row'+(idx===selectedIndex?' selected':'');row.dataset.index=idx;const nameLine=document.createElement('div');nameLine.style.display='flex';nameLine.style.justifyContent='space-between';nameLine.style.alignItems='center';const name=document.createElement('strong');name.textContent=`${game.emoji||''} ${game.title||game.id}`.trim();nameLine.appendChild(name);const idLabel=document.createElement('span');idLabel.className='pill';idLabel.textContent=game.id;nameLine.appendChild(idLabel);row.appendChild(nameLine);const meta=document.createElement('div');meta.className='meta';const statuses=[];if(Array.isArray(game.tags)){game.tags.filter(Boolean).forEach(tag=>statuses.push(tag))}flagFields.forEach(flag=>{if(game[flag])statuses.push(flag)});if(statuses.length){statuses.forEach(st=>{const badge=document.createElement('span');badge.className='badge';badge.textContent=st;meta.appendChild(badge)})}if(meta.childElementCount)row.appendChild(meta);row.onclick=()=>{selectedIndex=idx;renderList();renderEditor();};list.appendChild(row)});gameList.appendChild(list)}
@@ -102,6 +108,20 @@ function renderEditor(){
   pathInfo.innerHTML=`<strong>Path:</strong> ${escapeHTML(game.path||'')}`;
   form.appendChild(idInfo);
   form.appendChild(pathInfo);
+  if(!pendingAdds.some(it=>it.id===game.id)&&game.id){
+    const liveRow=document.createElement('div');
+    liveRow.className='row';
+    liveRow.style.margin='4px 0 0';
+    liveRow.style.gap='10px';
+    const liveLink=document.createElement('a');
+    liveLink.className='btn';
+    liveLink.href=`../games/${encodeURIComponent(game.id)}/`;
+    liveLink.target='_blank';
+    liveLink.rel='noopener';
+    liveLink.textContent='Open live page ↗';
+    liveRow.appendChild(liveLink);
+    form.appendChild(liveRow);
+  }
   editorPanel.appendChild(form);
   titleInput.addEventListener('input',()=>{
     game.title=titleInput.value;
@@ -152,20 +172,107 @@ drop.addEventListener('drop',async e=>{
     if(!confirm('Game id exists. Overwrite entry?'))return;
     games=games.filter(g=>g.id!==id);
     pendingAdds=pendingAdds.filter(it=>it.id!==id);
-    imports.querySelectorAll(`[data-id="${id}"]`).forEach(el=>el.remove());
+    imports.querySelectorAll(`[data-id="${id}"]`).forEach(el=>{if(el.previewState&&typeof el.previewState.destroy==='function')el.previewState.destroy();el.remove();});
   }
   const newEntry={id,title,path:`games/${id}/index.html`,description:'New uploaded game — update me!',tags:['new'],new:true,emoji:'🎮',addedAt:new Date().toISOString().slice(0,10)};
   if(thumbPath)newEntry.thumb=thumbPath;
   games=[...games,newEntry];
-  pendingAdds.push({id,zip,prefix,tf});
+  const record={id,zip,prefix,tf};
+  pendingAdds.push(record);
   selectedIndex=games.findIndex(g=>g.id===id);
   renderList();
   renderEditor();
   syncTextarea();
   const card=document.createElement('div');
-  card.className='mini';
+  card.className='mini import-card';
   card.dataset.id=id;
-  card.innerHTML=`<h4>${title}</h4><div class="row"><span class="pill">id: ${id}</span><span class="pill">path: games/${id}/index.html</span>${tf?'<span class="pill">thumb ✓</span>':''}</div><div class="row"><small>Files ready for export.</small></div>`;
+  const titleEl=document.createElement('h4');
+  titleEl.textContent=title;
+  card.appendChild(titleEl);
+  const pillRow=document.createElement('div');
+  pillRow.className='row';
+  pillRow.style.gap='8px';
+  const makePill=text=>{const span=document.createElement('span');span.className='pill';span.textContent=text;return span};
+  pillRow.appendChild(makePill('id: '+id));
+  pillRow.appendChild(makePill(`path: games/${id}/index.html`));
+  if(tf)pillRow.appendChild(makePill('thumb ✓'));
+  card.appendChild(pillRow);
+  const actions=document.createElement('div');
+  actions.className='import-actions';
+  const status=document.createElement('small');
+  status.textContent='Files ready for export.';
+  actions.appendChild(status);
+  const previewBtn=document.createElement('button');
+  previewBtn.type='button';
+  previewBtn.className='btn';
+  previewBtn.textContent='Preview';
+  actions.appendChild(previewBtn);
+  card.appendChild(actions);
+  const previewWrap=document.createElement('div');
+  previewWrap.className='preview-shell';
+  previewWrap.hidden=true;
+  const previewId=`preview-${id}-${Date.now()}`;
+  previewWrap.id=previewId;
+  const placeholder=document.createElement('div');
+  placeholder.className='preview-placeholder';
+  placeholder.textContent='Loading preview…';
+  previewWrap.appendChild(placeholder);
+  const frame=document.createElement('iframe');
+  frame.setAttribute('title',`${title} preview`);
+  frame.setAttribute('sandbox','allow-scripts allow-same-origin allow-pointer-lock allow-popups allow-forms');
+  frame.setAttribute('loading','lazy');
+  frame.allow='autoplay; fullscreen';
+  previewWrap.appendChild(frame);
+  const closeBtn=document.createElement('button');
+  closeBtn.type='button';
+  closeBtn.className='btn preview-close';
+  closeBtn.textContent='Close';
+  previewWrap.appendChild(closeBtn);
+  card.appendChild(previewWrap);
+  previewBtn.setAttribute('aria-controls',previewId);
+  previewBtn.setAttribute('aria-expanded','false');
+  const previewState={urls:[],active:false,token:null,cleanup(){this.urls.forEach(u=>URL.revokeObjectURL(u));this.urls=[];}};
+  previewState.close=({skipFocus}={})=>{previewState.token=null;previewState.cleanup();frame.srcdoc='';previewWrap.classList.remove('active');previewWrap.hidden=true;placeholder.hidden=true;placeholder.textContent='Loading preview…';previewState.active=false;previewBtn.textContent='Preview';previewBtn.setAttribute('aria-expanded','false');previewBtn.disabled=false;if(!skipFocus)previewBtn.focus?.();};
+  previewState.destroy=()=>{previewState.close({skipFocus:true});};
+  card.previewState=previewState;
+  closeBtn.addEventListener('click',()=>{previewState.close();});
+  previewBtn.addEventListener('click',async()=>{
+    if(previewState.active){
+      previewState.close();
+      return;
+    }
+    previewState.cleanup();
+    const token=Symbol('preview');
+    previewState.token=token;
+    previewBtn.disabled=true;
+    previewBtn.textContent='Loading…';
+    previewWrap.hidden=false;
+    previewWrap.classList.add('active');
+    placeholder.hidden=false;
+    placeholder.textContent='Loading preview…';
+    try{
+      await loadPreviewIntoFrame(record,frame,previewState,placeholder,token);
+      if(previewState.token!==token)return;
+      previewState.active=true;
+      previewBtn.textContent='Close preview';
+      previewBtn.setAttribute('aria-expanded','true');
+    }catch(err){
+      if(previewState.token!==token)return;
+      console.error('Preview failed for',id,err);
+      frame.srcdoc='';
+      previewState.cleanup();
+      previewState.active=false;
+      placeholder.hidden=false;
+      placeholder.textContent='Preview failed to load. Check console for details.';
+      previewWrap.hidden=false;
+      previewWrap.classList.add('active');
+      previewBtn.textContent='Preview';
+      previewBtn.setAttribute('aria-expanded','false');
+      previewState.token=null;
+    }finally{
+      previewBtn.disabled=false;
+    }
+  });
   imports.prepend(card);
 });
 document.getElementById('exportPatch').onclick=async()=>{syncTextarea();const out=new JSZip();out.file('games.json',ed.value);for(const it of pendingAdds){const base='games/'+it.id+'/';const entries=[];it.zip.forEach((p,f)=>{if(!f.dir)entries.push([p,f])});for(const [p,f] of entries){let rel=p.startsWith(it.prefix)?p.slice(it.prefix.length):p;if(!rel)continue;out.file(base+rel,await f.async('blob'))}if(it.tf)out.file('assets/thumbs/'+it.id+'.png',await it.tf.async('blob'))}const blob=await out.generateAsync({type:'blob'});dl('gurjots-games-patch.zip',blob)};


### PR DESCRIPTION
## Summary
- add a preview control and iframe container to ZIP import cards with styles that keep the form readable
- stream extracted index.html content from uploaded archives into the iframe via JSZip, rewriting asset URLs and cleaning up blob URLs on close
- expose a quick link for existing entries to open their /games/<id>/ page from the editor panel

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e44aaa7c008327a1db933ad38cebde