### PR TITLE
Add schema validation for game catalog

### DIFF
--- a/docs/game-doctor.md
+++ b/docs/game-doctor.md
@@ -1,0 +1,33 @@
+# Game Doctor
+
+`tools/game-doctor.mjs` performs consistency checks on `games.json` and the on-disk assets each game references.
+
+## Running the doctor
+
+```bash
+npm run doctor
+```
+
+The command generates `health/report.json` and `health/report.md` summaries. Use `--strict` (enabled in the npm script) to fail the run when new issues are introduced.
+
+## Schema validation
+
+Before any other check runs, Game Doctor validates `games.json` against [`tools/schemas/games.schema.json`](../tools/schemas/games.schema.json).
+
+The schema enforces:
+
+- required catalog fields (`id`, `slug`, `title`, `playUrl`, `firstFrame.sprites`, `help.tips`, etc.)
+- canonical formats (e.g. IDs/slugs are lowercase-hyphenated, `playUrl` ends with `/games/<slug>/`, ISO `released` dates, asset paths under `/assets/`)
+- no unexpected top-level, `firstFrame`, or `help` properties
+
+If validation fails you will see output similar to:
+
+```
+games.json failed schema validation:
+ - [3] › playUrl: value does not match required pattern "^/games/[a-z0-9-]+/$"
+ - [5] › help › tips: missing required property "0"
+```
+
+Interpret the path using `›` separators. For example, `[3]` refers to the fourth game entry. Fix the offending values in `games.json` until validation passes, then re-run the doctor.
+
+Once the schema passes, the tool continues with asset availability checks, manifest enforcement, and regression comparisons.

--- a/games.json
+++ b/games.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "pong",
+    "slug": "pong",
     "title": "Pong Classic",
     "short": "A snappy canvas remake of the arcade legend.",
     "tags": [
@@ -23,7 +24,7 @@
     },
     "help": {
       "objective": "Win rallies until you reach 11 points before your opponent.",
-      "controls": "Player 1: W/S to move. Player 2 (local) uses \u2191/\u2193. Press Space to pause or resume.",
+      "controls": "Player 1: W/S to move. Player 2 (local) uses ↑/↓. Press Space to pause or resume.",
       "tips": [
         "Angle the paddle to change the ball's direction and catch opponents off guard.",
         "Stay near the center between shots so you can react to either corner.",
@@ -38,6 +39,7 @@
   },
   {
     "id": "snake",
+    "slug": "snake",
     "title": "Snake",
     "short": "Eat, grow, don't bonk into yourself.",
     "tags": [
@@ -63,7 +65,7 @@
       "tips": [
         "Plan turns a few squares ahead to keep open lanes for future moves.",
         "Sweep the perimeter to straighten the snake before going for tight snacks.",
-        "Avoid reversing direction directly\u2014turn in an arc to stay safe."
+        "Avoid reversing direction directly—turn in an arc to stay safe."
       ],
       "steps": [
         "Press an arrow key to start moving.",
@@ -74,6 +76,7 @@
   },
   {
     "id": "tetris",
+    "slug": "tetris",
     "title": "Tetris",
     "short": "Classic falling blocks. Clear lines, level up.",
     "tags": [
@@ -98,7 +101,7 @@
     },
     "help": {
       "objective": "Clear horizontal lines by stacking falling tetrominoes without topping out.",
-      "controls": "\u2190/\u2192 move, \u2191 rotate, \u2193 soft drop, Space hard drop, P pause.",
+      "controls": "←/→ move, ↑ rotate, ↓ soft drop, Space hard drop, P pause.",
       "tips": [
         "Leave a clean lane on one side so I pieces can score Tetrises.",
         "Soft drop to adjust a piece before committing to a hard drop.",
@@ -113,6 +116,7 @@
   },
   {
     "id": "breakout",
+    "slug": "breakout",
     "title": "Breakout",
     "short": "Smash bricks, power-ups, chase the score.",
     "tags": [
@@ -136,7 +140,7 @@
     },
     "help": {
       "objective": "Break every brick on the stage while protecting your remaining lives.",
-      "controls": "Move the paddle with the mouse or \u2190/\u2192 keys. Click/tap to launch. P pauses, R restarts after a loss.",
+      "controls": "Move the paddle with the mouse or ←/→ keys. Click/tap to launch. P pauses, R restarts after a loss.",
       "tips": [
         "Catch falling power-ups to widen the paddle or add extra balls.",
         "Hit the ball off-center to steer shots into hard-to-reach bricks.",
@@ -151,6 +155,7 @@
   },
   {
     "id": "chess",
+    "slug": "chess",
     "title": "Chess (2D)",
     "short": "Traditional chess for two players.",
     "tags": [
@@ -161,6 +166,10 @@
     "released": "2025-08-20",
     "playUrl": "/games/chess/",
     "firstFrame": {
+      "sprites": [
+        "/assets/ui/panel.png",
+        "/assets/ui/star.png"
+      ],
       "audio": [
         "/assets/audio/click.wav"
       ]
@@ -171,7 +180,7 @@
       "tips": [
         "Control the center early so your pieces have maximum reach.",
         "Castle before your king comes under pressure.",
-        "Look for tactics after every move\u2014forks, pins, and discovered attacks."
+        "Look for tactics after every move—forks, pins, and discovered attacks."
       ],
       "steps": [
         "Choose a difficulty or puzzle, then make the first move.",
@@ -182,6 +191,7 @@
   },
   {
     "id": "chess3d",
+    "slug": "chess3d",
     "title": "Chess 3D (Local)",
     "short": "A three-dimensional chess experiment.",
     "tags": [
@@ -192,6 +202,10 @@
     "released": "2025-08-27",
     "playUrl": "/games/chess3d/",
     "firstFrame": {
+      "sprites": [
+        "/assets/sprites/chess3d/wood_light.png",
+        "/assets/sprites/chess3d/wood_dark.png"
+      ],
       "audio": [
         "/assets/audio/click.wav"
       ]
@@ -213,6 +227,7 @@
   },
   {
     "id": "2048",
+    "slug": "2048",
     "title": "2048",
     "short": "Slide numbers to reach 2048.",
     "tags": [
@@ -223,6 +238,9 @@
     "released": "2025-08-20",
     "playUrl": "/games/2048/",
     "firstFrame": {
+      "sprites": [
+        "/assets/sprites/block.png"
+      ],
       "audio": [
         "/assets/audio/click.wav"
       ]
@@ -244,6 +262,7 @@
   },
   {
     "id": "asteroids",
+    "slug": "asteroids",
     "title": "Asteroids",
     "short": "Pilot your ship and blast space rocks.",
     "tags": [
@@ -265,7 +284,7 @@
     },
     "help": {
       "objective": "Pilot your ship through space, blasting asteroids and enemies to survive each wave.",
-      "controls": "A/D or \u2190/\u2192 rotate, W or \u2191 thrust, Space/Enter fire, Shift/K hyperspace, P pause, R restart.",
+      "controls": "A/D or ←/→ rotate, W or ↑ thrust, Space/Enter fire, Shift/K hyperspace, P pause, R restart.",
       "tips": [
         "Fire in bursts so you can maneuver while shots travel.",
         "Use hyperspace when surrounded, but beware of random exits.",
@@ -280,6 +299,7 @@
   },
   {
     "id": "maze3d",
+    "slug": "maze3d",
     "title": "Maze 3D",
     "short": "Wander a first-person labyrinth to find the exit.",
     "tags": [
@@ -289,6 +309,10 @@
     "released": "2025-08-27",
     "playUrl": "/games/maze3d/",
     "firstFrame": {
+      "sprites": [
+        "/assets/sprites/maze3d/wall.png",
+        "/assets/sprites/maze3d/floor.png"
+      ],
       "audio": [
         "/assets/audio/powerup.wav"
       ]
@@ -310,6 +334,7 @@
   },
   {
     "id": "platformer",
+    "slug": "platformer",
     "title": "Pixel Platformer",
     "short": "Run and jump across platforms to reach the goal.",
     "tags": [
@@ -329,9 +354,9 @@
     },
     "help": {
       "objective": "Run, jump, and collect coins across the stage while staying ahead of hazards.",
-      "controls": "\u2190/\u2192 move, Space or \u2191 jump, P pause, R restart. Gamepad and co-op options live in the HUD.",
+      "controls": "←/→ move, Space or ↑ jump, P pause, R restart. Gamepad and co-op options live in the HUD.",
       "tips": [
-        "Collect every coin you see\u2014the goal only opens once the set is complete.",
+        "Collect every coin you see—the goal only opens once the set is complete.",
         "Time jumps off moving platforms and slopes to keep momentum going.",
         "Start co-op from the HUD if you want a partner to help sweep the map."
       ],
@@ -344,6 +369,7 @@
   },
   {
     "id": "runner",
+    "slug": "runner",
     "title": "City Runner",
     "short": "Dash through the city and avoid obstacles.",
     "tags": [
@@ -364,7 +390,7 @@
     },
     "help": {
       "objective": "Sprint through the city streets, dodging obstacles to keep your run alive.",
-      "controls": "Space or \u2191 jumps, \u2193 slides. On mobile, tap right to jump and left to slide.",
+      "controls": "Space or ↑ jumps, ↓ slides. On mobile, tap right to jump and left to slide.",
       "tips": [
         "Stay near the middle lane so you can quickly jump or slide as obstacles appear.",
         "Slide under low signs instead of jumping to recover faster afterward.",
@@ -379,6 +405,7 @@
   },
   {
     "id": "shooter",
+    "slug": "shooter",
     "title": "Alien Shooter",
     "short": "Blast waves of invaders and survive.",
     "tags": [
@@ -401,7 +428,7 @@
       "controls": "WASD or Arrow keys move, Space/Enter shoot. Keep moving to avoid hits.",
       "tips": [
         "Strafe horizontally to herd enemies into your bullet stream.",
-        "Watch your firing cadence\u2014the blaster has a short cooldown.",
+        "Watch your firing cadence—the blaster has a short cooldown.",
         "Keep distance from enemy clusters to buy time for dodges."
       ],
       "steps": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "acorn": "^8.15.0",
+        "ajv": "^8.17.1",
         "axe-core": "^4.10.3",
         "jsdom": "^24.0.0",
         "service-worker-mock": "^2.0.5",
@@ -970,15 +971,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1829,6 +1831,23 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/form-data": {
       "version": "4.0.4",
@@ -2872,6 +2891,22 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/service-worker-mock": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "acorn": "^8.15.0",
+    "ajv": "^8.17.1",
     "axe-core": "^4.10.3",
     "jsdom": "^24.0.0",
     "service-worker-mock": "^2.0.5",

--- a/tools/schemas/games.schema.json
+++ b/tools/schemas/games.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Gurjots Games catalog",
+  "description": "Schema describing the structure of games.json entries for Game Doctor checks.",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "slug",
+      "title",
+      "short",
+      "tags",
+      "difficulty",
+      "released",
+      "playUrl",
+      "firstFrame",
+      "help"
+    ],
+    "properties": {
+      "id": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$",
+        "minLength": 1
+      },
+      "slug": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$",
+        "minLength": 1
+      },
+      "title": {
+        "type": "string",
+        "minLength": 1
+      },
+      "short": {
+        "type": "string",
+        "minLength": 1
+      },
+      "tags": {
+        "type": "array",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9+\\-/ ]*$"
+        }
+      },
+      "difficulty": {
+        "type": "string",
+        "enum": ["easy", "medium", "hard"]
+      },
+      "released": {
+        "type": "string",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+      },
+      "playUrl": {
+        "type": "string",
+        "pattern": "^/games/[a-z0-9-]+/$"
+      },
+      "firstFrame": {
+        "type": "object",
+        "required": ["sprites"],
+        "additionalProperties": false,
+        "properties": {
+          "sprites": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^/assets/.+"
+            }
+          },
+          "audio": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^/assets/.+"
+            }
+          }
+        }
+      },
+      "help": {
+        "type": "object",
+        "required": ["objective", "controls", "tips", "steps"],
+        "additionalProperties": false,
+        "properties": {
+          "objective": {
+            "type": "string",
+            "minLength": 1
+          },
+          "controls": {
+            "type": "string",
+            "minLength": 1
+          },
+          "tips": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "steps": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a JSON Schema for `games.json` and require slugs, play URLs, and first-frame asset hints
- update the Game Doctor to validate the catalog with Ajv and display human-readable schema errors
- document the validation rules and update the catalog entries to satisfy the new schema requirements

## Testing
- node tools/game-doctor.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e53faea0b083278d728103d5e11ae1