### PR TITLE
Add regression tests for game doctor CLI

### DIFF
--- a/.github/workflows/game-doctor.yml
+++ b/.github/workflows/game-doctor.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run Game Doctor tests
+        run: npm run test:doctor
+
       - name: Run Game Doctor
         run: node tools/game-doctor.mjs --strict --baseline=health/baseline.json
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "npm run health && npm run test:unit",
     "test:unit": "vitest run",
+    "test:doctor": "vitest run tests/game-doctor.test.mjs",
     "test:smoke": "vitest run tests/runner.smoke.test.js",
     "sitemap": "node tools/generate-sitemap.mjs",
     "health": "node tools/healthcheck.mjs",

--- a/tests/fixtures/game-doctor-fixture.mjs
+++ b/tests/fixtures/game-doctor-fixture.mjs
@@ -1,0 +1,99 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+class GameDoctorFixture {
+  constructor(root) {
+    this.root = root;
+    this.gameDoctorPath = this.path('tools/game-doctor.mjs');
+  }
+
+  path(relativePath) {
+    return path.join(this.root, relativePath);
+  }
+
+  async writeFile(relativePath, contents = '') {
+    const absolutePath = this.path(relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, contents);
+  }
+
+  async writeJson(relativePath, data) {
+    await this.writeFile(relativePath, `${JSON.stringify(data, null, 2)}\n`);
+  }
+
+  async readFile(relativePath) {
+    const absolutePath = this.path(relativePath);
+    return fs.readFile(absolutePath, 'utf8');
+  }
+
+  async readJson(relativePath) {
+    const raw = await this.readFile(relativePath);
+    return JSON.parse(raw);
+  }
+
+  async runDoctor(args = [], { env = {} } = {}) {
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [this.gameDoctorPath, ...args], {
+        cwd: this.root,
+        env: { ...process.env, ...env },
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+
+      child.on('error', reject);
+      child.on('close', (code) => {
+        resolve({ code, stdout, stderr });
+      });
+    });
+  }
+
+  async cleanup() {
+    await fs.rm(this.root, { recursive: true, force: true });
+  }
+}
+
+async function copyFileIfExists(source, destination) {
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.copyFile(source, destination);
+}
+
+export async function createGameDoctorFixture(name = 'fixture') {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), `game-doctor-${name}-`));
+  const fixture = new GameDoctorFixture(tmpRoot);
+
+  await fs.mkdir(fixture.path('tools/reporters'), { recursive: true });
+  await fs.mkdir(fixture.path('assets'), { recursive: true });
+  await fs.mkdir(fixture.path('games'), { recursive: true });
+  await fs.mkdir(fixture.path('gameshells'), { recursive: true });
+  await fs.mkdir(fixture.path('health'), { recursive: true });
+
+  await copyFileIfExists(path.join(REPO_ROOT, 'tools', 'game-doctor.mjs'), fixture.path('tools/game-doctor.mjs'));
+  await copyFileIfExists(
+    path.join(REPO_ROOT, 'tools', 'reporters', 'game-doctor-manifest.json'),
+    fixture.path('tools/reporters/game-doctor-manifest.json'),
+  );
+  await copyFileIfExists(
+    path.join(REPO_ROOT, 'assets', 'placeholder-thumb.png'),
+    fixture.path('assets/placeholder-thumb.png'),
+  );
+
+  return fixture;
+}

--- a/tests/game-doctor.test.mjs
+++ b/tests/game-doctor.test.mjs
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createGameDoctorFixture } from './fixtures/game-doctor-fixture.mjs';
+
+let fixture;
+
+afterEach(async () => {
+  if (fixture) {
+    await fixture.cleanup();
+    fixture = null;
+  }
+});
+
+describe('tools/game-doctor.mjs', () => {
+  it('produces passing reports for healthy games', async () => {
+    fixture = await createGameDoctorFixture('healthy');
+
+    await fixture.writeJson('games.json', [
+      {
+        slug: 'healthy-game',
+        title: 'Healthy Fixture',
+        firstFrame: {
+          sprites: ['/assets/sprites/healthy-game.png'],
+          audio: ['/assets/audio/healthy-game.mp3'],
+        },
+      },
+    ]);
+
+    await fixture.writeFile('games/healthy-game/index.html', '<!doctype html><title>Healthy</title>');
+    await fixture.writeFile('assets/sprites/healthy-game.png', 'sprite-bytes');
+    await fixture.writeFile('assets/audio/healthy-game.mp3', 'audio-bytes');
+    await fixture.writeFile('assets/thumbs/healthy-game.png', 'thumb-bytes');
+
+    const result = await fixture.runDoctor();
+
+    expect(result.code).toBe(0);
+    expect(result.stderr.trim()).toBe('');
+    expect(result.stdout).toContain('Game doctor: all 1 game(s) look healthy!');
+
+    const report = await fixture.readJson('health/report.json');
+    expect(report.summary).toMatchObject({ total: 1, passing: 1, failing: 0 });
+    expect(report.games).toHaveLength(1);
+    expect(report.games[0].slug).toBe('healthy-game');
+    expect(report.games[0].ok).toBe(true);
+
+    const markdown = await fixture.readFile('health/report.md');
+    expect(markdown).toContain('## Healthy Fixture');
+    expect(markdown).toContain('- Status: ✅ Healthy');
+  });
+
+  it('fails strict mode when regressions are introduced', async () => {
+    fixture = await createGameDoctorFixture('regression');
+
+    await fixture.writeJson('games.json', [
+      {
+        slug: 'troubled-game',
+        title: 'Troubled Fixture',
+        firstFrame: {
+          sprites: ['/assets/sprites/missing.png'],
+        },
+      },
+    ]);
+
+    await fixture.writeJson('health/baseline.json', {
+      games: [
+        {
+          slug: 'troubled-game',
+          ok: true,
+        },
+      ],
+    });
+
+    const result = await fixture.runDoctor(['--strict', '--baseline=health/baseline.json']);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Game doctor strict mode detected 1 regression(s)');
+
+    const report = await fixture.readJson('health/report.json');
+    expect(report.summary).toMatchObject({ total: 1, passing: 0, failing: 1 });
+    expect(report.games[0].ok).toBe(false);
+    expect(report.games[0].issues.some((issue) => issue.message === 'Missing playable shell')).toBe(true);
+
+    const markdown = await fixture.readFile('health/report.md');
+    expect(markdown).toContain('## Troubled Fixture');
+    expect(markdown).toContain('❌ Needs attention');
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable fixture utility for spinning up isolated Game Doctor workspaces during tests
- cover healthy and regression scenarios with a dedicated Vitest suite that inspects reports and exit codes
- wire the new test:doctor npm script into the existing GitHub Actions workflow so regressions run automatically

## Testing
- npm run test:doctor

------
https://chatgpt.com/codex/tasks/task_e_68e53fb59fbc83279d01a2a7a5f7a37d