### PR TITLE
refactor: standardize diagnostics bootstrap across games

### DIFF
--- a/games/2048/index.html
+++ b/games/2048/index.html
@@ -456,9 +456,7 @@
 })();
 </script>
   <link rel="stylesheet" href="/games/common/diag-modal.css">
-  <script src="/games/common/diagnostics/report-store.js" defer></script>
   <script type="module" src="./diag-adapter.js"></script>
-  <script src="/games/common/diag-capture.js" defer></script>
 </body>
 </html>
 

--- a/games/breakout/index.html
+++ b/games/breakout/index.html
@@ -76,6 +76,5 @@
   })();
   </script>
   <script type="module" src="./adapter.js"></script>
-  <script src="/games/common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/chess/index.html
+++ b/games/chess/index.html
@@ -264,8 +264,5 @@
   })();
   </script>
   <link rel="stylesheet" href="/games/common/diag-modal.css">
-  <script src="/games/common/diagnostics/report-store.js" defer></script>
-  <script src="/games/common/diag-core.js" defer></script>
-  <script src="/games/common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/chess3d/index.html
+++ b/games/chess3d/index.html
@@ -259,8 +259,5 @@
   })();
   </script>
   <link rel="stylesheet" href="/games/common/diag-modal.css">
-  <script src="/games/common/diagnostics/report-store.js" defer></script>
-  <script src="/games/common/diag-core.js" defer></script>
-  <script src="/games/common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/maze3d/index.html
+++ b/games/maze3d/index.html
@@ -108,7 +108,6 @@
   <script type="module" src="./main.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="maze3d"></script>
   <script type="module" src="../common/game-shell.js" data-back-href="../../index.html" data-game="maze3d" data-apply-theme="false"></script>
-  <script src="/games/common/diag-autowire.js" defer></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/runner/index.html
+++ b/games/runner/index.html
@@ -255,8 +255,5 @@
   })();
   </script>
   <link rel="stylesheet" href="/games/common/diag-modal.css">
-  <script src="/games/common/diagnostics/report-store.js" defer></script>
-  <script src="/games/common/diag-core.js" defer></script>
-  <script src="/games/common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/shooter/index.html
+++ b/games/shooter/index.html
@@ -208,8 +208,5 @@
   })();
   </script>
   <link rel="stylesheet" href="/games/common/diag-modal.css">
-  <script src="/games/common/diagnostics/report-store.js" defer></script>
-  <script src="/games/common/diag-core.js" defer></script>
-  <script src="/games/common/diag-capture.js" defer></script>
 </body>
 </html>

--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -128,10 +128,8 @@
   <script src="../../js/sfx.js"></script>
   <script type="module" src="./snake.js"></script>
   <script type="module" src="../../shared/juice/overlay.js" data-game="snake"></script>
-  <script defer src="../common/game-shell.js" data-back-href="../../index.html" data-game="snake" data-diag-src="/games/common/diag-capture.js"></script>
+  <script defer src="../common/game-shell.js" data-back-href="../../index.html" data-game="snake"></script>
   <link rel="stylesheet" href="/games/common/diag-modal.css">
-  <script src="/games/common/diagnostics/report-store.js" defer></script>
-  <script src="/games/common/diag-core.js" defer></script>
 
   <!-- Auto-signal bootstrap: emits GAME_READY / GAME_ERROR to parent shell if the game doesn't -->
   <script>

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -114,8 +114,5 @@
   })();
   </script>
   <link rel="stylesheet" href="/games/common/diag-modal.css">
-  <script src="/games/common/diagnostics/report-store.js" defer></script>
-  <script src="/games/common/diag-core.js" defer></script>
-  <script src="/games/common/diag-capture.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove legacy diag-core and diag-capture script includes from game entrypoints
- rely on game shell's diag-autowire loader so diagnostics events flow through the shared adapter without duplication
- stop overriding the diagnostics source in Snake and drop redundant maze3d autowire include

## Testing
- not run (html-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e54a1a3e6883278e752911df98aad0