### PR TITLE
Add targeted Game Doctor support

### DIFF
--- a/.github/workflows/game-doctor.yml
+++ b/.github/workflows/game-doctor.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -25,8 +27,13 @@ jobs:
       - name: Run Game Doctor tests
         run: npm run test:doctor
 
-      - name: Run Game Doctor
-        run: node tools/game-doctor.mjs --strict --baseline=health/baseline.json
+      - name: Run Game Doctor (targeted)
+        if: github.event_name == 'pull_request' || github.ref != 'refs/heads/main'
+        run: npm run doctor:changed
+
+      - name: Run Game Doctor (full)
+        if: github.ref == 'refs/heads/main'
+        run: npm run doctor
 
       - name: Upload Game Doctor report
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ npm test             # runs the test suite
 
 ## Game Doctor continuous integration check
 
-Every push and pull request triggers the **Game Doctor** GitHub Action, which runs `node tools/game-doctor.mjs --strict --baseline=health/baseline.json` and fails the
+Every push and pull request triggers the **Game Doctor** GitHub Action. Pull requests run `npm run doctor:changed`, targeting only the slugs detected in the git diff, while pushes to `main` continue to run the full `npm run doctor` sweep. The workflow fails the
 check when any game needs attention. If you need to re-run the check, open your pull request, switch to the **Checks** tab,
 select **Game Doctor**, and click **Re-run**. The workflow uploads `health/report.json` and `health/report.md` as artifacts;
 download them from the same check summary to review the full report.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ To add new asset requirements:
 3. Keep requirements in arrays of strings—invalid entries will be treated
    as manifest errors during the health check.
 4. Run `node tools/game-doctor.mjs` (or `npm run doctor`) to confirm the
-   manifest changes pass.
+   manifest changes pass. Use `--slug=<slug>` to focus on specific games or
+   `npm run doctor:changed` to automatically target slugs detected from your
+   git diff against `origin/main`.
 
 ---
 

--- a/docs/game-doctor.md
+++ b/docs/game-doctor.md
@@ -10,6 +10,16 @@ npm run doctor
 
 The command generates `health/report.json` and `health/report.md` summaries. Use `--strict` (enabled in the npm script) to fail the run when new issues are introduced.
 
+### Targeted checks
+
+Pass one or more slugs to focus on a subset of games:
+
+```bash
+node tools/game-doctor.mjs --slug=pong,space-invaders
+```
+
+For continuous integration and local spot-checks, `npm run doctor:changed` inspects the git diff against `origin/main` to automatically determine which slugs were touched (falling back to a full run when detection is inconclusive).
+
 ## CI reporting
 
 Pull requests automatically surface Game Doctor results in a dedicated comment on the thread. The workflow parses `health/report.json` and renders a status table for every game, updating the same comment on reruns to avoid notification spam. A download link to the `game-doctor-report` workflow artifact (containing the JSON and Markdown outputs) is also included for deeper inspection.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "sitemap": "node tools/generate-sitemap.mjs",
     "health": "node tools/healthcheck.mjs",
     "doctor": "node tools/game-doctor.mjs --strict --baseline=health/baseline.json",
+    "doctor:changed": "node tools/game-doctor.mjs --strict --baseline=health/baseline.json --changed",
     "sync:games": "node tools/sync-game-catalog.mjs",
     "deploy": "npx wrangler deploy --config wrangler.toml",
     "deploy:check": "npx wrangler deploy --config wrangler.toml --dry-run"

--- a/tests/fixtures/game-doctor-fixture.mjs
+++ b/tests/fixtures/game-doctor-fixture.mjs
@@ -80,6 +80,7 @@ export async function createGameDoctorFixture(name = 'fixture') {
   const fixture = new GameDoctorFixture(tmpRoot);
 
   await fs.mkdir(fixture.path('tools/reporters'), { recursive: true });
+  await fs.mkdir(fixture.path('tools/schemas'), { recursive: true });
   await fs.mkdir(fixture.path('assets'), { recursive: true });
   await fs.mkdir(fixture.path('games'), { recursive: true });
   await fs.mkdir(fixture.path('gameshells'), { recursive: true });
@@ -91,9 +92,21 @@ export async function createGameDoctorFixture(name = 'fixture') {
     fixture.path('tools/reporters/game-doctor-manifest.json'),
   );
   await copyFileIfExists(
+    path.join(REPO_ROOT, 'tools', 'schemas', 'games.schema.json'),
+    fixture.path('tools/schemas/games.schema.json'),
+  );
+  await copyFileIfExists(
     path.join(REPO_ROOT, 'assets', 'placeholder-thumb.png'),
     fixture.path('assets/placeholder-thumb.png'),
   );
+
+  try {
+    await fs.symlink(path.join(REPO_ROOT, 'node_modules'), fixture.path('node_modules'), 'dir');
+  } catch (error) {
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  }
 
   return fixture;
 }


### PR DESCRIPTION
## Summary
- add slug-based filtering and git-powered change detection to `tools/game-doctor.mjs`
- add a targeted npm script, documentation, and tests covering the new CLI options
- update the Game Doctor workflow to run the focused mode on pull requests while keeping full runs on `main`

## Testing
- npm run test:doctor

------
https://chatgpt.com/codex/tasks/task_e_68e5499911ac8327a956079310624809