### PR TITLE
Add coverage for unhealthy game doctor runs

### DIFF
--- a/tests/game-doctor.test.mjs
+++ b/tests/game-doctor.test.mjs
@@ -83,4 +83,67 @@ describe('tools/game-doctor.mjs', () => {
     expect(markdown).toContain('## Troubled Fixture');
     expect(markdown).toContain('❌ Needs attention');
   });
+
+  it('lists all detected issues for unhealthy games', async () => {
+    fixture = await createGameDoctorFixture('unhealthy');
+
+    await fixture.writeJson('games.json', [
+      {
+        slug: 'unhealthy-game',
+        title: 'Unhealthy Fixture',
+        firstFrame: {
+          sprites: [
+            '/assets/sprites/unhealthy-game.png',
+            '/assets/missing-sprite.png',
+            'bad-sprite',
+          ],
+          audio: ['/assets/audio/unhealthy-game.mp3', 'bad-audio'],
+        },
+      },
+    ]);
+
+    await fixture.writeFile('assets/sprites/unhealthy-game.png', 'sprite-bytes');
+    await fixture.writeJson('tools/reporters/game-doctor-manifest.json', {
+      version: 1,
+      requirements: {
+        'unhealthy-game': 'invalid-requirements-entry',
+      },
+    });
+
+    const result = await fixture.runDoctor();
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Game doctor found 1 of 1 game(s) with issues');
+
+    const report = await fixture.readJson('health/report.json');
+    expect(report.summary).toMatchObject({ total: 1, passing: 0, failing: 1 });
+
+    const [gameReport] = report.games;
+    expect(gameReport.slug).toBe('unhealthy-game');
+    expect(gameReport.ok).toBe(false);
+
+    const issueMessages = gameReport.issues.map((issue) => issue.message);
+    expect(issueMessages).toEqual(
+      expect.arrayContaining([
+        'Missing playable shell',
+        'Manifest requirements entry must be an object',
+        'Sprite asset missing on disk',
+        'Sprite asset must live under /assets/',
+        'Audio asset missing on disk',
+        'Audio asset must live under /assets/',
+      ]),
+    );
+
+    expect(gameReport.assets.sprites).toEqual(
+      expect.arrayContaining(['assets/sprites/unhealthy-game.png']),
+    );
+    expect(gameReport.assets.audio).toEqual([]);
+
+    const markdown = await fixture.readFile('health/report.md');
+    expect(markdown).toContain('## Unhealthy Fixture');
+    expect(markdown).toContain('- Issues:');
+    expect(markdown).toContain('Missing playable shell');
+    expect(markdown).toContain('Sprite asset must live under /assets/');
+    expect(markdown).toContain('Audio asset must live under /assets/');
+  });
 });


### PR DESCRIPTION
## Summary
- add a regression test that exercises game doctor issue reporting
- ensure the new fixture covers missing shells, bad assets, and invalid manifest entries

## Testing
- npm test -- game-doctor.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e54b5f448c83279b2c73a216334ea0