### PR TITLE
Guard Game Doctor comments when pull request missing

### DIFF
--- a/.github/workflows/game-doctor.yml
+++ b/.github/workflows/game-doctor.yml
@@ -74,6 +74,12 @@ jobs:
             let summaryText = '⚠️ Game Doctor report was not generated.';
             let table = '';
 
+            const issueNumber = context.payload?.pull_request?.number;
+            if (!issueNumber) {
+              core.info('Skipping Game Doctor comment: no pull request context available.');
+              return;
+            }
+
             if (fs.existsSync(path)) {
               try {
                 const report = JSON.parse(fs.readFileSync(path, 'utf8'));
@@ -130,7 +136,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner,
               repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
               per_page: 100,
             });
 
@@ -147,7 +153,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner,
                 repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body: commentBody,
               });
             }


### PR DESCRIPTION
## Summary
- skip the GitHub Script comment step when the workflow lacks pull request context
- reuse the detected pull request number instead of dereferencing an undefined context.issue

## Testing
- not run (CI configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e5611c97708327b4eaa96c4da1f808