### PR TITLE
Add opt-in baseline regeneration flag to game doctor

### DIFF
--- a/tools/game-doctor.mjs
+++ b/tools/game-doctor.mjs
@@ -537,10 +537,22 @@ function buildMarkdownReport(report) {
   return lines.join('\n');
 }
 
+const WRITE_BASELINE_ENV = 'GAME_DOCTOR_ALLOW_WRITE_BASELINE';
+
+function isBaselineWriteEnabled() {
+  const flag = process.env[WRITE_BASELINE_ENV];
+  if (!flag) {
+    return false;
+  }
+  const normalized = String(flag).trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
+
 function parseCliArgs() {
   const args = process.argv.slice(2);
   let strictMode = false;
   let baselinePath = DEFAULT_BASELINE;
+  let writeBaseline = false;
 
   for (const arg of args) {
     if (arg === '--strict') {
@@ -550,10 +562,37 @@ function parseCliArgs() {
       if (value.trim()) {
         baselinePath = path.isAbsolute(value) ? value : path.join(ROOT, value);
       }
+    } else if (arg === '--write-baseline') {
+      writeBaseline = true;
     }
   }
 
-  return { strictMode, baselinePath };
+  return { strictMode, baselinePath, writeBaseline };
+}
+
+function buildBaselinePayload(report) {
+  const games = report.games.map((game) => {
+    const entry = {
+      index: game.index,
+      title: game.title,
+      slug: game.slug,
+      ok: game.ok,
+      issues: game.issues,
+      shell: game.shell,
+      assets: game.assets,
+      thumbnail: game.thumbnail,
+    };
+    if (game.requirements) {
+      entry.requirements = game.requirements;
+    }
+    return entry;
+  });
+
+  return {
+    generatedAt: report.generatedAt,
+    summary: report.summary,
+    games,
+  };
 }
 
 function mapBaselineGames(baseline) {
@@ -590,7 +629,15 @@ function selectBaselineEntry(game, maps) {
 }
 
 async function main() {
-  const { strictMode, baselinePath } = parseCliArgs();
+  const { strictMode, baselinePath, writeBaseline } = parseCliArgs();
+
+  if (writeBaseline && !isBaselineWriteEnabled()) {
+    console.error(
+      `--write-baseline requested but ${WRITE_BASELINE_ENV} is not enabled. Refusing to write baseline.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
 
   let validateGames;
   try {
@@ -817,6 +864,16 @@ async function main() {
   await fs.mkdir(HEALTH_DIR, { recursive: true });
   await fs.writeFile(REPORT_JSON, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   await fs.writeFile(REPORT_MD, `${buildMarkdownReport(report)}\n`, 'utf8');
+
+  if (writeBaseline) {
+    const baselineDir = path.dirname(baselinePath);
+    await fs.mkdir(baselineDir, { recursive: true });
+    const payload = buildBaselinePayload(report);
+    await fs.writeFile(baselinePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    console.log(
+      `Game doctor baseline written to ${relativeFromRoot(baselinePath)}.`,
+    );
+  }
 
   if (strictMode) {
     const regressions = [];


### PR DESCRIPTION
## Summary
- add an opt-in `--write-baseline` CLI flag for Game Doctor
- require the `GAME_DOCTOR_ALLOW_WRITE_BASELINE` env var before writing baseline files
- reuse the generated report to produce sanitized baseline payloads at any specified path

## Testing
- GAME_DOCTOR_ALLOW_WRITE_BASELINE=1 node tools/game-doctor.mjs --baseline=health/tmp-baseline.json --write-baseline

------
https://chatgpt.com/codex/tasks/task_e_68e562cdb8608327a44f05bfc88379df