### PR TITLE
Highlight placeholder thumbnails as warnings

### DIFF
--- a/docs/custom-thumbnails.md
+++ b/docs/custom-thumbnails.md
@@ -1,0 +1,41 @@
+# Supplying bespoke game thumbnails
+
+High quality thumbnails help each game stand out in catalogs and storefronts. The Game Doctor tooling now surfaces placeholder art usage as a warning so teams can quickly spot where bespoke imagery is still needed. This guide walks through replacing the shared placeholder thumbnail with custom art for each title.
+
+## Where thumbnails live
+
+Game Doctor searches for thumbnails in the following locations, in order:
+
+1. `assets/thumbs/<slug>.png`
+2. `games/<slug>/thumb.png`
+3. `assets/placeholder-thumb.png`
+
+If neither of the slug-specific files exist, the scanner falls back to `assets/placeholder-thumb.png` and emits a warning in the health report.
+
+## Creating a custom thumbnail
+
+1. Export a 512×512 PNG (square art works best) with transparency disabled.
+2. Name the file after the game slug (for example, `pong` becomes `pong.png`).
+3. Save the file to `assets/thumbs/<slug>.png`.
+   - Alternatively, place the file beside the shell HTML at `games/<slug>/thumb.png` if you prefer to keep art with the game implementation.
+4. Commit the new asset.
+
+The Game Doctor report will automatically pick up the tailored art on the next run.
+
+## Verifying locally
+
+After adding thumbnails, run the health check locally:
+
+```bash
+npm run health:games
+```
+
+The summary now includes a "with warnings" count. If your game still references the placeholder art, you will see a ⚠️ warning entry under the game section with remediation guidance.
+
+## Tips for better catalog polish
+
+- Keep important details centered so they remain visible when cropped.
+- Use bold silhouettes and minimal text for clarity at smaller sizes.
+- Update thumbnails whenever the visual identity of the game changes.
+
+Publishing bespoke thumbnails alongside your game ensures the catalog experience remains consistent and polished.

--- a/health/report.json
+++ b/health/report.json
@@ -1,9 +1,10 @@
 {
-  "generatedAt": "2025-10-06T22:49:41.382Z",
+  "generatedAt": "2025-10-07T20:23:32.951Z",
   "summary": {
     "total": 12,
     "passing": 12,
-    "failing": 0
+    "failing": 0,
+    "withWarnings": 6
   },
   "manifest": {
     "version": 1,
@@ -31,7 +32,12 @@
         ]
       },
       "thumbnail": {
-        "found": "games/pong/thumb.png"
+        "found": "games/pong/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
       },
       "requirements": {
         "paths": [
@@ -80,7 +86,16 @@
       "title": "Snake",
       "slug": "snake",
       "ok": true,
-      "issues": [],
+      "issues": [
+        {
+          "message": "Thumbnail uses placeholder art",
+          "context": {
+            "thumbnail": "assets/placeholder-thumb.png",
+            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+          },
+          "severity": "warning"
+        }
+      ],
       "shell": {
         "found": "games/snake/index.html"
       },
@@ -95,7 +110,12 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "assets/placeholder-thumb.png",
+        "placeholder": true
+      },
+      "status": {
+        "errors": false,
+        "warnings": true
       }
     },
     {
@@ -103,7 +123,16 @@
       "title": "Tetris",
       "slug": "tetris",
       "ok": true,
-      "issues": [],
+      "issues": [
+        {
+          "message": "Thumbnail uses placeholder art",
+          "context": {
+            "thumbnail": "assets/placeholder-thumb.png",
+            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+          },
+          "severity": "warning"
+        }
+      ],
       "shell": {
         "found": "games/tetris/index.html"
       },
@@ -121,7 +150,12 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "assets/placeholder-thumb.png",
+        "placeholder": true
+      },
+      "status": {
+        "errors": false,
+        "warnings": true
       }
     },
     {
@@ -129,7 +163,16 @@
       "title": "Breakout",
       "slug": "breakout",
       "ok": true,
-      "issues": [],
+      "issues": [
+        {
+          "message": "Thumbnail uses placeholder art",
+          "context": {
+            "thumbnail": "assets/placeholder-thumb.png",
+            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+          },
+          "severity": "warning"
+        }
+      ],
       "shell": {
         "found": "games/breakout/index.html"
       },
@@ -146,7 +189,12 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "assets/placeholder-thumb.png",
+        "placeholder": true
+      },
+      "status": {
+        "errors": false,
+        "warnings": true
       }
     },
     {
@@ -154,18 +202,35 @@
       "title": "Chess (2D)",
       "slug": "chess",
       "ok": true,
-      "issues": [],
+      "issues": [
+        {
+          "message": "Thumbnail uses placeholder art",
+          "context": {
+            "thumbnail": "assets/placeholder-thumb.png",
+            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+          },
+          "severity": "warning"
+        }
+      ],
       "shell": {
         "found": "games/chess/index.html"
       },
       "assets": {
-        "sprites": [],
+        "sprites": [
+          "assets/ui/panel.png",
+          "assets/ui/star.png"
+        ],
         "audio": [
           "assets/audio/click.wav"
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "assets/placeholder-thumb.png",
+        "placeholder": true
+      },
+      "status": {
+        "errors": false,
+        "warnings": true
       }
     },
     {
@@ -173,18 +238,35 @@
       "title": "Chess 3D (Local)",
       "slug": "chess3d",
       "ok": true,
-      "issues": [],
+      "issues": [
+        {
+          "message": "Thumbnail uses placeholder art",
+          "context": {
+            "thumbnail": "assets/placeholder-thumb.png",
+            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+          },
+          "severity": "warning"
+        }
+      ],
       "shell": {
         "found": "games/chess3d/index.html"
       },
       "assets": {
-        "sprites": [],
+        "sprites": [
+          "assets/sprites/chess3d/wood_light.png",
+          "assets/sprites/chess3d/wood_dark.png"
+        ],
         "audio": [
           "assets/audio/click.wav"
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "assets/placeholder-thumb.png",
+        "placeholder": true
+      },
+      "status": {
+        "errors": false,
+        "warnings": true
       }
     },
     {
@@ -192,18 +274,34 @@
       "title": "2048",
       "slug": "2048",
       "ok": true,
-      "issues": [],
+      "issues": [
+        {
+          "message": "Thumbnail uses placeholder art",
+          "context": {
+            "thumbnail": "assets/placeholder-thumb.png",
+            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+          },
+          "severity": "warning"
+        }
+      ],
       "shell": {
         "found": "games/2048/index.html"
       },
       "assets": {
-        "sprites": [],
+        "sprites": [
+          "assets/sprites/block.png"
+        ],
         "audio": [
           "assets/audio/click.wav"
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "assets/placeholder-thumb.png",
+        "placeholder": true
+      },
+      "status": {
+        "errors": false,
+        "warnings": true
       }
     },
     {
@@ -226,7 +324,12 @@
         ]
       },
       "thumbnail": {
-        "found": "games/asteroids/thumb.png"
+        "found": "games/asteroids/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
       }
     },
     {
@@ -239,13 +342,21 @@
         "found": "games/maze3d/index.html"
       },
       "assets": {
-        "sprites": [],
+        "sprites": [
+          "assets/sprites/maze3d/wall.png",
+          "assets/sprites/maze3d/floor.png"
+        ],
         "audio": [
           "assets/audio/powerup.wav"
         ]
       },
       "thumbnail": {
-        "found": "games/maze3d/thumb.png"
+        "found": "games/maze3d/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
       }
     },
     {
@@ -267,7 +378,12 @@
         ]
       },
       "thumbnail": {
-        "found": "games/platformer/thumb.png"
+        "found": "games/platformer/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
       },
       "requirements": {
         "paths": [
@@ -319,7 +435,12 @@
         ]
       },
       "thumbnail": {
-        "found": "games/runner/thumb.png"
+        "found": "games/runner/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
       }
     },
     {
@@ -341,7 +462,12 @@
         ]
       },
       "thumbnail": {
-        "found": "games/shooter/thumb.png"
+        "found": "games/shooter/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
       }
     }
   ]

--- a/health/report.md
+++ b/health/report.md
@@ -1,10 +1,11 @@
 # Game Doctor Report
 
-Generated: 2025-10-06T22:49:41.382Z
+Generated: 2025-10-07T20:23:32.951Z
 
 - Total games: 12
 - Passing: 12
 - Failing: 0
+- With warnings: 6
 - Manifest version: 1
 - Manifest source: tools/reporters/game-doctor-manifest.json
 
@@ -23,59 +24,80 @@ Generated: 2025-10-06T22:49:41.382Z
 ## Snake
 
 - Slug: snake
-- Status: ✅ Healthy
+- Status: ⚠️ Review warnings
 - Shell: games/snake/index.html
-- Thumbnail: assets/placeholder-thumb.png
+- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
 - Sprites checked: 1
 - Audio checked: 3
-- Issues: none
+- Issues:
+  - ⚠️ Warning: Thumbnail uses placeholder art
+    - thumbnail: "assets/placeholder-thumb.png"
+    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
 
 ## Tetris
 
 - Slug: tetris
-- Status: ✅ Healthy
+- Status: ⚠️ Review warnings
 - Shell: games/tetris/index.html
-- Thumbnail: assets/placeholder-thumb.png
+- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
 - Sprites checked: 4
 - Audio checked: 3
-- Issues: none
+- Issues:
+  - ⚠️ Warning: Thumbnail uses placeholder art
+    - thumbnail: "assets/placeholder-thumb.png"
+    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
 
 ## Breakout
 
 - Slug: breakout
-- Status: ✅ Healthy
+- Status: ⚠️ Review warnings
 - Shell: games/breakout/index.html
-- Thumbnail: assets/placeholder-thumb.png
+- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
 - Sprites checked: 3
 - Audio checked: 3
-- Issues: none
+- Issues:
+  - ⚠️ Warning: Thumbnail uses placeholder art
+    - thumbnail: "assets/placeholder-thumb.png"
+    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
 
 ## Chess (2D)
 
 - Slug: chess
-- Status: ✅ Healthy
+- Status: ⚠️ Review warnings
 - Shell: games/chess/index.html
-- Thumbnail: assets/placeholder-thumb.png
+- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Sprites checked: 2
 - Audio checked: 1
-- Issues: none
+- Issues:
+  - ⚠️ Warning: Thumbnail uses placeholder art
+    - thumbnail: "assets/placeholder-thumb.png"
+    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
 
 ## Chess 3D (Local)
 
 - Slug: chess3d
-- Status: ✅ Healthy
+- Status: ⚠️ Review warnings
 - Shell: games/chess3d/index.html
-- Thumbnail: assets/placeholder-thumb.png
+- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Sprites checked: 2
 - Audio checked: 1
-- Issues: none
+- Issues:
+  - ⚠️ Warning: Thumbnail uses placeholder art
+    - thumbnail: "assets/placeholder-thumb.png"
+    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
 
 ## 2048
 
 - Slug: 2048
-- Status: ✅ Healthy
+- Status: ⚠️ Review warnings
 - Shell: games/2048/index.html
-- Thumbnail: assets/placeholder-thumb.png
+- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Sprites checked: 1
 - Audio checked: 1
-- Issues: none
+- Issues:
+  - ⚠️ Warning: Thumbnail uses placeholder art
+    - thumbnail: "assets/placeholder-thumb.png"
+    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
 
 ## Asteroids
 
@@ -93,6 +115,7 @@ Generated: 2025-10-06T22:49:41.382Z
 - Status: ✅ Healthy
 - Shell: games/maze3d/index.html
 - Thumbnail: games/maze3d/thumb.png
+- Sprites checked: 2
 - Audio checked: 1
 - Issues: none
 

--- a/tools/comment-game-doctor.mjs
+++ b/tools/comment-game-doctor.mjs
@@ -37,7 +37,9 @@ async function readSummaryLine() {
     const total = summary.total ?? 0;
     const passing = summary.passing ?? 0;
     const failing = summary.failing ?? 0;
-    return `**Summary:** ${passing}/${total} passing · ${failing} failing.`;
+    const warnings = summary.withWarnings ?? 0;
+    const warningSegment = warnings > 0 ? ` · ${warnings} with warnings` : '';
+    return `**Summary:** ${passing}/${total} passing · ${failing} failing${warningSegment}.`;
   } catch (error) {
     warn(`Unable to read summary from ${path.relative(ROOT, REPORT_JSON_PATH)}: ${error.message}`);
     return null;


### PR DESCRIPTION
## Summary
- add issue severity metadata so Game Doctor can warn when placeholder thumbnails are detected
- surface warning counts in the markdown report, CLI messaging, and GitHub summary commenter
- document how to create bespoke thumbnails for each game entry

## Testing
- node tools/game-doctor.mjs
- npm run test:doctor

------
https://chatgpt.com/codex/tasks/task_e_68e576296b44832797f3673a7f4b3119