### PR TITLE
Update Wrangler worker name to match dashboard

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "game-library"
+name = "gurjots-games"
 main = "cloudflare/worker.ts"
 compatibility_date = "2024-06-20"
 


### PR DESCRIPTION
## Summary
- align the Wrangler configuration's Worker name with the deployed Cloudflare Worker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5780f20488327a871f1df7e716f75