### PR TITLE
Ensure setMapping initializes per-player handler maps

### DIFF
--- a/src/runtime/controls.js
+++ b/src/runtime/controls.js
@@ -56,7 +56,10 @@ export class Controls {
 
   /** Change mapping for an action at runtime */
   setMapping(action, key, player = 0) {
-    if (!this.maps[player]) this.maps[player] = {};
+    if (!this.maps[player]) {
+      this.maps[player] = {};
+      if (!this.handlers[player]) this.handlers[player] = new Map();
+    }
     this.maps[player][action] = key;
     if (player === 0) {
       const binding = this.touchBindings.get(action);

--- a/src/runtime/controls.ts
+++ b/src/runtime/controls.ts
@@ -73,7 +73,10 @@ export class Controls {
 
   /** Change mapping for an action at runtime */
   setMapping(action: string, key: string | string[], player = 0): void {
-    if (!this.maps[player]) this.maps[player] = {};
+    if (!this.maps[player]) {
+      this.maps[player] = {};
+      if (!this.handlers[player]) this.handlers[player] = new Map();
+    }
     this.maps[player][action] = key;
     if (player === 0) {
       const binding = this.touchBindings.get(action);


### PR DESCRIPTION
## Summary
- lazily create player mapping entries in `Controls#setMapping`
- ensure handler maps are instantiated for new players
- update the compiled runtime bundle to match the TypeScript source

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e57e79df2483278dfdb24fa2f7fd8e