### PR TITLE
Ensure control handlers initialize lazily

### DIFF
--- a/src/runtime/controls.js
+++ b/src/runtime/controls.js
@@ -34,13 +34,18 @@ export class Controls {
     if (opts.touch !== false) this.buildTouch();
   }
 
+  ensureHandlerMap(player) {
+    if (!this.handlers[player]) this.handlers[player] = new Map();
+    return this.handlers[player];
+  }
+
   /** Register callback for an action. Returns unsubscribe function. */
   on(action, cb, player = 0) {
-    if (!this.handlers[player]) this.handlers[player] = new Map();
-    let set = this.handlers[player].get(action);
+    const handlers = this.ensureHandlerMap(player);
+    let set = handlers.get(action);
     if (!set) {
       set = new Set();
-      this.handlers[player].set(action, set);
+      handlers.set(action, set);
     }
     set.add(cb);
     return () => set.delete(cb);
@@ -57,6 +62,7 @@ export class Controls {
   /** Change mapping for an action at runtime */
   setMapping(action, key, player = 0) {
     if (!this.maps[player]) this.maps[player] = {};
+    this.ensureHandlerMap(player);
     this.maps[player][action] = key;
     if (player === 0) {
       const binding = this.touchBindings.get(action);
@@ -111,8 +117,8 @@ export class Controls {
 
   fireByCode(code) {
     for (let p = 0; p < this.maps.length; p++) {
+      this.ensureHandlerMap(p);
       const map = this.maps[p];
-      if (!this.handlers[p]) this.handlers[p] = new Map();
       for (const action in map) {
         if (this.match(action, code, p)) this.fire(action, p);
       }

--- a/src/runtime/controls.ts
+++ b/src/runtime/controls.ts
@@ -55,10 +55,17 @@ export class Controls {
     if (opts.touch !== false) this.buildTouch();
   }
 
+  private ensureHandlerMap(player: number): Map<string, Set<() => void>> {
+    let map = this.handlers[player];
+    if (!map) this.handlers[player] = map = new Map();
+    return map;
+  }
+
   /** Register callback for an action. Returns unsubscribe function. */
   on(action: string, cb: () => void, player = 0): () => void {
-    let set = this.handlers[player].get(action);
-    if (!set) this.handlers[player].set(action, (set = new Set()));
+    const handlers = this.ensureHandlerMap(player);
+    let set = handlers.get(action);
+    if (!set) handlers.set(action, (set = new Set()));
     set.add(cb);
     return () => set!.delete(cb);
   }
@@ -74,6 +81,7 @@ export class Controls {
   /** Change mapping for an action at runtime */
   setMapping(action: string, key: string | string[], player = 0): void {
     if (!this.maps[player]) this.maps[player] = {};
+    this.ensureHandlerMap(player);
     this.maps[player][action] = key;
     if (player === 0) {
       const binding = this.touchBindings.get(action);
@@ -118,12 +126,13 @@ export class Controls {
   }
 
   private fire(action: string, player: number): void {
-    const set = this.handlers[player].get(action);
+    const set = this.handlers[player]?.get(action);
     if (set) for (const fn of Array.from(set)) fn();
   }
 
   private fireByCode(code: string): void {
     for (let p = 0; p < this.maps.length; p++) {
+      this.ensureHandlerMap(p);
       for (const action in this.maps[p]) {
         if (this.match(action, code, p)) this.fire(action, p);
       }


### PR DESCRIPTION
## Summary
- add an internal helper that lazily initializes handler maps for each player
- update Controls helpers to use the new guard so handler lookups no longer assume pre-existing maps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e57e8b1d048327bd2af8e43b6f2b1b