### PR TITLE
Fix codemod scripts syntax and adjust router import

### DIFF
--- a/js/game-shell.js
+++ b/js/game-shell.js
@@ -419,16 +419,16 @@ function ensureOverlays(){
     err.setAttribute('aria-hidden', 'true');
     err.setAttribute('aria-labelledby', 'error-message');
     err.setAttribute('aria-describedby', 'error-details');
-    err.innerHTML = '
-      <div class="panel">
-        <div class="message" id="error-message"></div>
-        <button type="button" class="toggle" aria-expanded="false">Show details</button>
-        <pre class="details" id="error-details" aria-hidden="true"></pre>
-        <div style="margin-top:10px;display:flex;gap:8px;justify-content:center">
-         <button class="btn" id="btn-restart">Retry</button>
-          <a class="btn" id="open-new" target="_blank" rel="noopener">Open in new tab</a>
-        </div>
-      </div>';
+    err.innerHTML = `
+        <div class="panel">
+          <div class="message" id="error-message"></div>
+          <button type="button" class="toggle" aria-expanded="false">Show details</button>
+          <pre class="details" id="error-details" aria-hidden="true"></pre>
+          <div style="margin-top:10px;display:flex;gap:8px;justify-content:center">
+            <button class="btn" id="btn-restart">Retry</button>
+            <a class="btn" id="open-new" target="_blank" rel="noopener">Open in new tab</a>
+          </div>
+        </div>`;
     stage.appendChild(err);
   }
 

--- a/scripts/codemod-assert-to-console.mjs
+++ b/scripts/codemod-assert-to-console.mjs
@@ -1,4 +1,3 @@
-\
 /**
  * Usage:
  *   node scripts/codemod-assert-to-console.mjs

--- a/scripts/codemod-remove-json-assert.mjs
+++ b/scripts/codemod-remove-json-assert.mjs
@@ -1,4 +1,3 @@
-\
 /**
  * Usage:
  *   node scripts/codemod-remove-json-assert.mjs
@@ -25,24 +24,25 @@ const re = /import\s+(\w+)\s+from\s+["']([^"']+\.json)["']\s+assert\s*\{\s*type\
 
 let changed = 0;
 for (const file of files) {
-  let src = fs.readFileSync(file, "utf8");
-  if (!re.test(src)) continue;
-  src = src.replace(re, (_m, ident, rel) => {
-    // Insert a top-level helper if not present
-    const helper = `\nasync function __loadJSON__(p){const r=await fetch(new URL(p, import.meta.url));return r.json();}\n`;
-    let out = src;
-    if (!out.includes("async function __loadJSON__")) {
-      out = helper + out;
-    }
-    // Replace the import with a top-level const that awaits the helper.
-    // Note: if the file isn't already an async module, we wrap later code in an IIFE.
-    const replacement = `const ${ident} = await __loadJSON__('${rel}');`;
-    out = out.replace(_m, replacement);
-    // Ensure module can use top-level await by marking type=module from HTML or bundler.
-    return out;
-  });
-  fs.writeFileSync(file, src, "utf8");
+  const src = fs.readFileSync(file, "utf8");
+  if (!re.test(src)) {
+    continue;
+  }
+
+  re.lastIndex = 0;
+
+  let out = src;
+  const helper = "async function __loadJSON__(p){const r=await fetch(new URL(p, import.meta.url));return r.json();}\n\n";
+
+  if (!out.includes("async function __loadJSON__")) {
+    out = `${helper}${out}`;
+  }
+
+  out = out.replace(re, (_m, ident, rel) => `const ${ident} = await __loadJSON__('${rel}');`);
+
+  fs.writeFileSync(file, out, "utf8");
   changed++;
   console.log("[codemod] Rewrote JSON import assertion in", file);
 }
+
 console.log("[codemod] Files changed:", changed);

--- a/src/router.ts
+++ b/src/router.ts
@@ -124,7 +124,7 @@ export class Router {
   }
 
   private async renderNotFound(mode: ResolveMode, path: string) {
-    const mod = await import('./pages/not-found.js');
+    const mod = await import('../scripts/pages/not-found.js');
     this.outlet.innerHTML = '';
     mod.default(this.outlet);
     this.commitHistory(path, mode);


### PR DESCRIPTION
## Summary
- remove stray escape characters at the top of codemod scripts that broke parsing
- harden the JSON import codemod to add its helper once and rewrite assertions correctly
- switch the router 404 fallback to import the existing not-found page and fix the game shell overlay markup string

## Testing
- node --check scripts/codemod-assert-to-console.mjs
- node --check scripts/codemod-remove-json-assert.mjs
- node --check js/game-shell.js

------
https://chatgpt.com/codex/tasks/task_e_68e57f76006c8327b7e90a5a5e9a5df5