### PR TITLE
Replace placeholder thumbnails with inline SVG art

### DIFF
--- a/docs/custom-thumbnails.md
+++ b/docs/custom-thumbnails.md
@@ -6,18 +6,18 @@ High quality thumbnails help each game stand out in catalogs and storefronts. Th
 
 Game Doctor searches for thumbnails in the following locations, in order:
 
-1. `assets/thumbs/<slug>.png`
-2. `games/<slug>/thumb.png`
+1. `assets/thumbs/<slug>.(png|jpg|jpeg|webp|gif|svg)`
+2. `games/<slug>/thumb.(png|jpg|jpeg|webp|gif|svg)`
 3. `assets/placeholder-thumb.png`
 
 If neither of the slug-specific files exist, the scanner falls back to `assets/placeholder-thumb.png` and emits a warning in the health report.
 
 ## Creating a custom thumbnail
 
-1. Export a 512×512 PNG (square art works best) with transparency disabled.
-2. Name the file after the game slug (for example, `pong` becomes `pong.png`).
-3. Save the file to `assets/thumbs/<slug>.png`.
-   - Alternatively, place the file beside the shell HTML at `games/<slug>/thumb.png` if you prefer to keep art with the game implementation.
+1. Export a 512×512 image — PNG, WebP, JPEG, GIF, or SVG all work. Solid backgrounds generally compress better than alpha transparency.
+2. Name the file after the game slug (for example, `pong` becomes `pong.png` or `pong.svg`).
+3. Save the file to `assets/thumbs/<slug>.<ext>` where `<ext>` matches the chosen format.
+   - Alternatively, place the file beside the shell HTML at `games/<slug>/thumb.<ext>` if you prefer to keep art with the game implementation.
 4. Commit the new asset.
 
 The Game Doctor report will automatically pick up the tailored art on the next run.

--- a/games.json
+++ b/games.json
@@ -49,6 +49,7 @@
     "difficulty": "easy",
     "released": "2025-08-25",
     "playUrl": "/games/snake/",
+    "thumbnail": "/games/snake/thumb.svg",
     "firstFrame": {
       "sprites": [
         "/assets/sprites/coin.png"
@@ -86,6 +87,7 @@
     "difficulty": "medium",
     "released": "2025-08-26",
     "playUrl": "/games/tetris/",
+    "thumbnail": "/games/tetris/thumb.svg",
     "firstFrame": {
       "sprites": [
         "/assets/sprites/block.png",
@@ -126,6 +128,7 @@
     "difficulty": "medium",
     "released": "2025-08-26",
     "playUrl": "/games/breakout/",
+    "thumbnail": "/games/breakout/thumb.svg",
     "firstFrame": {
       "sprites": [
         "/assets/sprites/paddle.png",
@@ -165,6 +168,7 @@
     "difficulty": "hard",
     "released": "2025-08-20",
     "playUrl": "/games/chess/",
+    "thumbnail": "/games/chess/thumb.svg",
     "firstFrame": {
       "sprites": [
         "/assets/ui/panel.png",
@@ -201,6 +205,7 @@
     "difficulty": "hard",
     "released": "2025-08-27",
     "playUrl": "/games/chess3d/",
+    "thumbnail": "/games/chess3d/thumb.svg",
     "firstFrame": {
       "sprites": [
         "/assets/sprites/chess3d/wood_light.png",
@@ -237,6 +242,7 @@
     "difficulty": "medium",
     "released": "2025-08-20",
     "playUrl": "/games/2048/",
+    "thumbnail": "/games/2048/thumb.svg",
     "firstFrame": {
       "sprites": [
         "/assets/sprites/block.png"

--- a/games/2048/thumb.svg
+++ b/games/2048/thumb.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90" role="img" aria-labelledby="title desc">
+  <title id="title">2048 thumbnail</title>
+  <desc id="desc">Golden 2048 tile surrounded by merging squares.</desc>
+  <defs>
+    <linearGradient id="bg2048" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2a1a12"/>
+      <stop offset="100%" stop-color="#3a2318"/>
+    </linearGradient>
+    <linearGradient id="tile" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f6d365"/>
+      <stop offset="100%" stop-color="#fda085"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="90" fill="url(#bg2048)"/>
+  <g transform="translate(28,20)" opacity="0.4">
+    <rect x="0" y="0" width="32" height="32" rx="6" fill="#f4a261"/>
+    <rect x="84" y="10" width="32" height="32" rx="6" fill="#e76f51"/>
+    <rect x="48" y="36" width="32" height="32" rx="6" fill="#2a9d8f"/>
+  </g>
+  <rect x="52" y="24" width="56" height="56" rx="12" fill="url(#tile)" stroke="#fff2d8" stroke-width="4"/>
+  <text x="80" y="64" font-family="'Rubik', 'Helvetica', 'Arial', sans-serif" font-size="26" font-weight="700" text-anchor="middle" fill="#fffaf0">2048</text>
+</svg>

--- a/games/breakout/thumb.svg
+++ b/games/breakout/thumb.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90" role="img" aria-labelledby="title desc">
+  <title id="title">Breakout thumbnail</title>
+  <desc id="desc">A paddle deflects a glowing ball toward rows of bricks.</desc>
+  <defs>
+    <linearGradient id="bbg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1b0f3b"/>
+      <stop offset="100%" stop-color="#090414"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="90" fill="url(#bbg)"/>
+  <g transform="translate(20,16)" stroke="#221144" stroke-width="2" stroke-linejoin="round">
+    <rect x="0" y="0" width="24" height="12" fill="#ff7676"/>
+    <rect x="26" y="0" width="24" height="12" fill="#ffd166"/>
+    <rect x="52" y="0" width="24" height="12" fill="#06d6a0"/>
+    <rect x="78" y="0" width="24" height="12" fill="#118ab2"/>
+    <rect x="0" y="14" width="24" height="12" fill="#ffd166"/>
+    <rect x="26" y="14" width="24" height="12" fill="#06d6a0"/>
+    <rect x="52" y="14" width="24" height="12" fill="#118ab2"/>
+    <rect x="78" y="14" width="24" height="12" fill="#ff7676"/>
+  </g>
+  <rect x="48" y="68" width="64" height="10" rx="5" fill="#f7f7ff" stroke="#3a3a7a" stroke-width="3"/>
+  <circle cx="90" cy="46" r="8" fill="#f8f9ff" stroke="#6dd5ff" stroke-width="4"/>
+  <path d="M90 46 L115 35" stroke="#6dd5ff" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+</svg>

--- a/games/chess/thumb.svg
+++ b/games/chess/thumb.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90" role="img" aria-labelledby="title desc">
+  <title id="title">Chess thumbnail</title>
+  <desc id="desc">Chess pieces on a board with alternating squares.</desc>
+  <defs>
+    <linearGradient id="cbg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1e1f24"/>
+      <stop offset="100%" stop-color="#101117"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="90" fill="url(#cbg)"/>
+  <g transform="translate(30,20)">
+    <rect x="0" y="0" width="100" height="50" fill="#d2b48c" stroke="#593d2b" stroke-width="4"/>
+    <g fill="#b07a48">
+      <rect x="0" y="0" width="12.5" height="12.5"/>
+      <rect x="25" y="0" width="12.5" height="12.5"/>
+      <rect x="50" y="0" width="12.5" height="12.5"/>
+      <rect x="75" y="0" width="12.5" height="12.5"/>
+      <rect x="12.5" y="12.5" width="12.5" height="12.5"/>
+      <rect x="37.5" y="12.5" width="12.5" height="12.5"/>
+      <rect x="62.5" y="12.5" width="12.5" height="12.5"/>
+      <rect x="87.5" y="12.5" width="12.5" height="12.5"/>
+    </g>
+    <g transform="translate(12,5)" fill="#fff" stroke="#d8d8d8" stroke-width="3" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M0 36h12l3 6h-18z"/>
+      <path d="M6 12l-4 12h8z"/>
+      <circle cx="6" cy="8" r="3"/>
+    </g>
+    <g transform="translate(58,2)" fill="#fff" stroke="#d8d8d8" stroke-width="3" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M0 40h16l4 6h-24z"/>
+      <path d="M8 14l-6 10h12z"/>
+      <circle cx="8" cy="10" r="4"/>
+      <rect x="6" y="4" width="4" height="4"/>
+    </g>
+    <g transform="translate(34,6)" fill="#2c2c2c" stroke="#0e0e0e" stroke-width="3" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M0 38h14l4 6h-22z"/>
+      <path d="M7 16l-5 10h10z"/>
+      <circle cx="7" cy="12" r="3"/>
+      <rect x="6" y="6" width="2" height="4"/>
+    </g>
+  </g>
+</svg>

--- a/games/chess3d/thumb.svg
+++ b/games/chess3d/thumb.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90" role="img" aria-labelledby="title desc">
+  <title id="title">3D Chess thumbnail</title>
+  <desc id="desc">Isometric chessboard floating with highlighted squares.</desc>
+  <defs>
+    <linearGradient id="c3bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#070b22"/>
+      <stop offset="100%" stop-color="#131b45"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="90" fill="url(#c3bg)"/>
+  <g transform="translate(80,50) skewX(-20) skewY(-10) scale(0.9)">
+    <rect x="-40" y="-40" width="80" height="80" fill="#f7e1c6" stroke="#3a2618" stroke-width="5"/>
+    <g fill="#c08a54">
+      <rect x="-40" y="-40" width="10" height="10"/>
+      <rect x="-20" y="-40" width="10" height="10"/>
+      <rect x="0" y="-40" width="10" height="10"/>
+      <rect x="20" y="-40" width="10" height="10"/>
+      <rect x="-30" y="-30" width="10" height="10"/>
+      <rect x="-10" y="-30" width="10" height="10"/>
+      <rect x="10" y="-30" width="10" height="10"/>
+      <rect x="30" y="-30" width="10" height="10"/>
+      <rect x="-40" y="-20" width="10" height="10"/>
+      <rect x="-20" y="-20" width="10" height="10"/>
+      <rect x="0" y="-20" width="10" height="10"/>
+      <rect x="20" y="-20" width="10" height="10"/>
+      <rect x="-30" y="-10" width="10" height="10"/>
+      <rect x="-10" y="-10" width="10" height="10"/>
+      <rect x="10" y="-10" width="10" height="10"/>
+      <rect x="30" y="-10" width="10" height="10"/>
+    </g>
+    <g fill="#ffffff" stroke="#d6d6d6" stroke-width="4" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M-10 20h12l3 6h-18z"/>
+      <path d="M-4 2l-4 12h8z"/>
+      <circle cx="0" cy="-2" r="3"/>
+    </g>
+    <g fill="#1d223a" stroke="#0b0d16" stroke-width="4" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M18 25h14l4 6h-22z"/>
+      <path d="M25 6l-5 10h10z"/>
+      <circle cx="25" cy="2" r="3"/>
+    </g>
+    <polygon points="-40 -40 -30 -35 -30 -45" fill="#f7e1c6" opacity="0.3"/>
+  </g>
+  <path d="M30 82h100" stroke="#4ec5ff" stroke-width="4" stroke-linecap="round" opacity="0.6"/>
+</svg>

--- a/games/snake/thumb.svg
+++ b/games/snake/thumb.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90" role="img" aria-labelledby="title desc">
+  <title id="title">Snake thumbnail</title>
+  <desc id="desc">Green snake winding toward a red apple on a dark grid.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0b3d2e"/>
+      <stop offset="100%" stop-color="#042015"/>
+    </linearGradient>
+    <pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse">
+      <rect x="0" y="0" width="10" height="10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="160" height="90" fill="url(#bg)"/>
+  <rect width="160" height="90" fill="url(#grid)"/>
+  <path d="M20 70h40v-20h20v-20h40v20h-20v20h-40v20h-20z" fill="#5de06d" stroke="#173f2e" stroke-width="4" stroke-linejoin="round"/>
+  <circle cx="125" cy="25" r="8" fill="#e84141" stroke="#7a1c1c" stroke-width="3"/>
+  <path d="M125 17c3 0 6 3 6 6" stroke="#2f7c2f" stroke-width="3" stroke-linecap="round" fill="none"/>
+</svg>

--- a/games/tetris/thumb.svg
+++ b/games/tetris/thumb.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90" role="img" aria-labelledby="title desc">
+  <title id="title">Tetris thumbnail</title>
+  <desc id="desc">Stack of colorful tetromino blocks against a deep blue backdrop.</desc>
+  <defs>
+    <linearGradient id="tbg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#061b3a"/>
+      <stop offset="100%" stop-color="#0d2f6a"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="90" fill="url(#tbg)"/>
+  <g stroke="#1a1d2b" stroke-width="3" stroke-linejoin="round">
+    <rect x="18" y="50" width="24" height="24" fill="#f8d74a"/>
+    <rect x="42" y="50" width="24" height="24" fill="#f49846"/>
+    <rect x="66" y="50" width="24" height="24" fill="#7ed957"/>
+    <rect x="90" y="50" width="24" height="24" fill="#5ad1ff"/>
+    <rect x="114" y="50" width="24" height="24" fill="#d867f4"/>
+    <rect x="42" y="26" width="24" height="24" fill="#f25f5c"/>
+    <rect x="66" y="26" width="24" height="24" fill="#f8d74a"/>
+    <rect x="90" y="26" width="24" height="24" fill="#7ed957"/>
+    <rect x="90" y="2" width="24" height="24" fill="#f49846"/>
+  </g>
+  <rect x="18" y="74" width="120" height="6" fill="#0a1329" opacity="0.6"/>
+</svg>

--- a/health/baseline.json
+++ b/health/baseline.json
@@ -1,9 +1,14 @@
 {
-  "generatedAt": "2025-10-06T22:32:21.773Z",
+  "generatedAt": "2025-10-07T21:13:46.273Z",
   "summary": {
     "total": 12,
     "passing": 12,
-    "failing": 0
+    "failing": 0,
+    "withWarnings": 0
+  },
+  "manifest": {
+    "version": 1,
+    "source": "tools/reporters/game-doctor-manifest.json"
   },
   "games": [
     {
@@ -27,7 +32,53 @@
         ]
       },
       "thumbnail": {
-        "found": "games/pong/thumb.png"
+        "found": "games/pong/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "manifest.json",
+            "found": true,
+            "resolved": "games/pong/manifest.json"
+          },
+          {
+            "requirement": "pong.css",
+            "found": true,
+            "resolved": "games/pong/pong.css"
+          }
+        ],
+        "globs": [
+          {
+            "pattern": "*.js",
+            "matches": [
+              {
+                "relativeToShell": "adapter.js",
+                "relativeToRoot": "games/pong/adapter.js"
+              },
+              {
+                "relativeToShell": "career.js",
+                "relativeToRoot": "games/pong/career.js"
+              },
+              {
+                "relativeToShell": "main.js",
+                "relativeToRoot": "games/pong/main.js"
+              },
+              {
+                "relativeToShell": "pauseOverlay.js",
+                "relativeToRoot": "games/pong/pauseOverlay.js"
+              },
+              {
+                "relativeToShell": "pong.js",
+                "relativeToRoot": "games/pong/pong.js"
+              }
+            ]
+          }
+        ]
       }
     },
     {
@@ -50,7 +101,22 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "games/snake/thumb.svg",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "snake.js",
+            "found": true,
+            "resolved": "games/snake/snake.js"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -76,7 +142,47 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "games/tetris/thumb.svg",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "tetris.js",
+            "found": true,
+            "resolved": "games/tetris/tetris.js"
+          },
+          {
+            "requirement": "engine.js",
+            "found": true,
+            "resolved": "games/tetris/engine.js"
+          },
+          {
+            "requirement": "replay.js",
+            "found": true,
+            "resolved": "games/tetris/replay.js"
+          },
+          {
+            "requirement": "play.html",
+            "found": true,
+            "resolved": "games/tetris/play.html"
+          },
+          {
+            "requirement": "replays/list.json",
+            "found": true,
+            "resolved": "games/tetris/replays/list.json"
+          },
+          {
+            "requirement": "replays/sample-replay.json",
+            "found": true,
+            "resolved": "games/tetris/replays/sample-replay.json"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -101,7 +207,37 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "games/breakout/thumb.svg",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "breakout.js",
+            "found": true,
+            "resolved": "games/breakout/breakout.js"
+          },
+          {
+            "requirement": "levels.js",
+            "found": true,
+            "resolved": "games/breakout/levels.js"
+          },
+          {
+            "requirement": "powerups.js",
+            "found": true,
+            "resolved": "games/breakout/powerups.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/breakout/adapter.js"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -114,13 +250,61 @@
         "found": "games/chess/index.html"
       },
       "assets": {
-        "sprites": [],
+        "sprites": [
+          "assets/ui/panel.png",
+          "assets/ui/star.png"
+        ],
         "audio": [
           "assets/audio/click.wav"
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "games/chess/thumb.svg",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "chess.js",
+            "found": true,
+            "resolved": "games/chess/chess.js"
+          },
+          {
+            "requirement": "ai.js",
+            "found": true,
+            "resolved": "games/chess/ai.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/chess/net.js"
+          },
+          {
+            "requirement": "puzzles.js",
+            "found": true,
+            "resolved": "games/chess/puzzles.js"
+          },
+          {
+            "requirement": "ratings.js",
+            "found": true,
+            "resolved": "games/chess/ratings.js"
+          },
+          {
+            "requirement": "engine/rules.js",
+            "found": true,
+            "resolved": "games/chess/engine/rules.js"
+          },
+          {
+            "requirement": "engine/chess.min.js",
+            "found": true,
+            "resolved": "games/chess/engine/chess.min.js"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -133,13 +317,161 @@
         "found": "games/chess3d/index.html"
       },
       "assets": {
-        "sprites": [],
+        "sprites": [
+          "assets/sprites/chess3d/wood_light.png",
+          "assets/sprites/chess3d/wood_dark.png"
+        ],
         "audio": [
           "assets/audio/click.wav"
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "games/chess3d/thumb.svg",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/chess3d/main.js"
+          },
+          {
+            "requirement": "board.js",
+            "found": true,
+            "resolved": "games/chess3d/board.js"
+          },
+          {
+            "requirement": "input.js",
+            "found": true,
+            "resolved": "games/chess3d/input.js"
+          },
+          {
+            "requirement": "pieces.js",
+            "found": true,
+            "resolved": "games/chess3d/pieces.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/chess3d/adapter.js"
+          }
+        ],
+        "globs": [
+          {
+            "pattern": "textures/*.js",
+            "matches": [
+              {
+                "relativeToShell": "textures/env.js",
+                "relativeToRoot": "games/chess3d/textures/env.js"
+              },
+              {
+                "relativeToShell": "textures/marble.js",
+                "relativeToRoot": "games/chess3d/textures/marble.js"
+              },
+              {
+                "relativeToShell": "textures/wood.js",
+                "relativeToRoot": "games/chess3d/textures/wood.js"
+              }
+            ]
+          },
+          {
+            "pattern": "ui/*.js",
+            "matches": [
+              {
+                "relativeToShell": "ui/cameraPresets.js",
+                "relativeToRoot": "games/chess3d/ui/cameraPresets.js"
+              },
+              {
+                "relativeToShell": "ui/clocks.js",
+                "relativeToRoot": "games/chess3d/ui/clocks.js"
+              },
+              {
+                "relativeToShell": "ui/coords.js",
+                "relativeToRoot": "games/chess3d/ui/coords.js"
+              },
+              {
+                "relativeToShell": "ui/evalBar.js",
+                "relativeToRoot": "games/chess3d/ui/evalBar.js"
+              },
+              {
+                "relativeToShell": "ui/highlight.js",
+                "relativeToRoot": "games/chess3d/ui/highlight.js"
+              },
+              {
+                "relativeToShell": "ui/hud.js",
+                "relativeToRoot": "games/chess3d/ui/hud.js"
+              },
+              {
+                "relativeToShell": "ui/lastMove.js",
+                "relativeToRoot": "games/chess3d/ui/lastMove.js"
+              },
+              {
+                "relativeToShell": "ui/modeBar.js",
+                "relativeToRoot": "games/chess3d/ui/modeBar.js"
+              },
+              {
+                "relativeToShell": "ui/movelist.js",
+                "relativeToRoot": "games/chess3d/ui/movelist.js"
+              },
+              {
+                "relativeToShell": "ui/promotionModal.js",
+                "relativeToRoot": "games/chess3d/ui/promotionModal.js"
+              },
+              {
+                "relativeToShell": "ui/themePicker.js",
+                "relativeToRoot": "games/chess3d/ui/themePicker.js"
+              }
+            ]
+          },
+          {
+            "pattern": "modes/*.js",
+            "matches": [
+              {
+                "relativeToShell": "modes/analysis.js",
+                "relativeToRoot": "games/chess3d/modes/analysis.js"
+              }
+            ]
+          },
+          {
+            "pattern": "ai/*.js",
+            "matches": [
+              {
+                "relativeToShell": "ai/ai.js",
+                "relativeToRoot": "games/chess3d/ai/ai.js"
+              },
+              {
+                "relativeToShell": "ai/simpleEngine.js",
+                "relativeToRoot": "games/chess3d/ai/simpleEngine.js"
+              },
+              {
+                "relativeToShell": "ai/stockfish.js",
+                "relativeToRoot": "games/chess3d/ai/stockfish.js"
+              },
+              {
+                "relativeToShell": "ai/stockfish.worker.js",
+                "relativeToRoot": "games/chess3d/ai/stockfish.worker.js"
+              }
+            ]
+          },
+          {
+            "pattern": "lib/*.js",
+            "matches": [
+              {
+                "relativeToShell": "lib/OrbitControls.js",
+                "relativeToRoot": "games/chess3d/lib/OrbitControls.js"
+              },
+              {
+                "relativeToShell": "lib/three.module.js",
+                "relativeToRoot": "games/chess3d/lib/three.module.js"
+              }
+            ]
+          }
+        ]
       }
     },
     {
@@ -152,13 +484,55 @@
         "found": "games/2048/index.html"
       },
       "assets": {
-        "sprites": [],
+        "sprites": [
+          "assets/sprites/block.png"
+        ],
         "audio": [
           "assets/audio/click.wav"
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png"
+        "found": "games/2048/thumb.svg",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "2048.js",
+            "found": true,
+            "resolved": "games/2048/2048.js"
+          },
+          {
+            "requirement": "engine.js",
+            "found": true,
+            "resolved": "games/2048/engine.js"
+          },
+          {
+            "requirement": "g2048.js",
+            "found": true,
+            "resolved": "games/2048/g2048.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/2048/net.js"
+          },
+          {
+            "requirement": "diag-adapter.js",
+            "found": true,
+            "resolved": "games/2048/diag-adapter.js"
+          },
+          {
+            "requirement": "assets/board-bg.png",
+            "found": true,
+            "resolved": "games/2048/assets/board-bg.png"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -181,7 +555,42 @@
         ]
       },
       "thumbnail": {
-        "found": "games/asteroids/thumb.png"
+        "found": "games/asteroids/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/asteroids/main.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/asteroids/net.js"
+          },
+          {
+            "requirement": "enemies.js",
+            "found": true,
+            "resolved": "games/asteroids/enemies.js"
+          },
+          {
+            "requirement": "diag-adapter.js",
+            "found": true,
+            "resolved": "games/asteroids/diag-adapter.js"
+          },
+          {
+            "requirement": "thumb.png",
+            "found": true,
+            "resolved": "games/asteroids/thumb.png"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -194,13 +603,51 @@
         "found": "games/maze3d/index.html"
       },
       "assets": {
-        "sprites": [],
+        "sprites": [
+          "assets/sprites/maze3d/wall.png",
+          "assets/sprites/maze3d/floor.png"
+        ],
         "audio": [
           "assets/audio/powerup.wav"
         ]
       },
       "thumbnail": {
-        "found": "games/maze3d/thumb.png"
+        "found": "games/maze3d/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/maze3d/main.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/maze3d/net.js"
+          },
+          {
+            "requirement": "generator.js",
+            "found": true,
+            "resolved": "games/maze3d/generator.js"
+          },
+          {
+            "requirement": "PointerLockControls.js",
+            "found": true,
+            "resolved": "games/maze3d/PointerLockControls.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/maze3d/adapter.js"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -222,7 +669,56 @@
         ]
       },
       "thumbnail": {
-        "found": "games/platformer/thumb.png"
+        "found": "games/platformer/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "levels",
+            "found": true,
+            "resolved": "games/platformer/levels"
+          },
+          {
+            "requirement": "tiles.js",
+            "found": true,
+            "resolved": "games/platformer/tiles.js"
+          },
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/platformer/main.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/platformer/net.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/platformer/adapter.js"
+          }
+        ],
+        "globs": [
+          {
+            "pattern": "levels/*.json",
+            "matches": [
+              {
+                "relativeToShell": "levels/level1.json",
+                "relativeToRoot": "games/platformer/levels/level1.json"
+              },
+              {
+                "relativeToShell": "levels/level2.json",
+                "relativeToRoot": "games/platformer/levels/level2.json"
+              }
+            ]
+          }
+        ]
       }
     },
     {
@@ -245,7 +741,47 @@
         ]
       },
       "thumbnail": {
-        "found": "games/runner/thumb.png"
+        "found": "games/runner/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/runner/main.js"
+          },
+          {
+            "requirement": "editor.js",
+            "found": true,
+            "resolved": "games/runner/editor.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/runner/adapter.js"
+          },
+          {
+            "requirement": "levels.json",
+            "found": true,
+            "resolved": "games/runner/levels.json"
+          },
+          {
+            "requirement": "sample-level.json",
+            "found": true,
+            "resolved": "games/runner/sample-level.json"
+          },
+          {
+            "requirement": "thumb.png",
+            "found": true,
+            "resolved": "games/runner/thumb.png"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -267,7 +803,37 @@
         ]
       },
       "thumbnail": {
-        "found": "games/shooter/thumb.png"
+        "found": "games/shooter/thumb.png",
+        "placeholder": false
+      },
+      "status": {
+        "errors": false,
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/shooter/main.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/shooter/net.js"
+          },
+          {
+            "requirement": "diagnostics-adapter.js",
+            "found": true,
+            "resolved": "games/shooter/diagnostics-adapter.js"
+          },
+          {
+            "requirement": "thumb.png",
+            "found": true,
+            "resolved": "games/shooter/thumb.png"
+          }
+        ],
+        "globs": []
       }
     }
   ]

--- a/health/report.json
+++ b/health/report.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2025-10-07T20:23:32.951Z",
+  "generatedAt": "2025-10-07T21:13:46.273Z",
   "summary": {
     "total": 12,
     "passing": 12,
     "failing": 0,
-    "withWarnings": 6
+    "withWarnings": 0
   },
   "manifest": {
     "version": 1,
@@ -86,16 +86,7 @@
       "title": "Snake",
       "slug": "snake",
       "ok": true,
-      "issues": [
-        {
-          "message": "Thumbnail uses placeholder art",
-          "context": {
-            "thumbnail": "assets/placeholder-thumb.png",
-            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
-          },
-          "severity": "warning"
-        }
-      ],
+      "issues": [],
       "shell": {
         "found": "games/snake/index.html"
       },
@@ -110,12 +101,22 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png",
-        "placeholder": true
+        "found": "games/snake/thumb.svg",
+        "placeholder": false
       },
       "status": {
         "errors": false,
-        "warnings": true
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "snake.js",
+            "found": true,
+            "resolved": "games/snake/snake.js"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -123,16 +124,7 @@
       "title": "Tetris",
       "slug": "tetris",
       "ok": true,
-      "issues": [
-        {
-          "message": "Thumbnail uses placeholder art",
-          "context": {
-            "thumbnail": "assets/placeholder-thumb.png",
-            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
-          },
-          "severity": "warning"
-        }
-      ],
+      "issues": [],
       "shell": {
         "found": "games/tetris/index.html"
       },
@@ -150,12 +142,47 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png",
-        "placeholder": true
+        "found": "games/tetris/thumb.svg",
+        "placeholder": false
       },
       "status": {
         "errors": false,
-        "warnings": true
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "tetris.js",
+            "found": true,
+            "resolved": "games/tetris/tetris.js"
+          },
+          {
+            "requirement": "engine.js",
+            "found": true,
+            "resolved": "games/tetris/engine.js"
+          },
+          {
+            "requirement": "replay.js",
+            "found": true,
+            "resolved": "games/tetris/replay.js"
+          },
+          {
+            "requirement": "play.html",
+            "found": true,
+            "resolved": "games/tetris/play.html"
+          },
+          {
+            "requirement": "replays/list.json",
+            "found": true,
+            "resolved": "games/tetris/replays/list.json"
+          },
+          {
+            "requirement": "replays/sample-replay.json",
+            "found": true,
+            "resolved": "games/tetris/replays/sample-replay.json"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -163,16 +190,7 @@
       "title": "Breakout",
       "slug": "breakout",
       "ok": true,
-      "issues": [
-        {
-          "message": "Thumbnail uses placeholder art",
-          "context": {
-            "thumbnail": "assets/placeholder-thumb.png",
-            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
-          },
-          "severity": "warning"
-        }
-      ],
+      "issues": [],
       "shell": {
         "found": "games/breakout/index.html"
       },
@@ -189,12 +207,37 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png",
-        "placeholder": true
+        "found": "games/breakout/thumb.svg",
+        "placeholder": false
       },
       "status": {
         "errors": false,
-        "warnings": true
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "breakout.js",
+            "found": true,
+            "resolved": "games/breakout/breakout.js"
+          },
+          {
+            "requirement": "levels.js",
+            "found": true,
+            "resolved": "games/breakout/levels.js"
+          },
+          {
+            "requirement": "powerups.js",
+            "found": true,
+            "resolved": "games/breakout/powerups.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/breakout/adapter.js"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -202,16 +245,7 @@
       "title": "Chess (2D)",
       "slug": "chess",
       "ok": true,
-      "issues": [
-        {
-          "message": "Thumbnail uses placeholder art",
-          "context": {
-            "thumbnail": "assets/placeholder-thumb.png",
-            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
-          },
-          "severity": "warning"
-        }
-      ],
+      "issues": [],
       "shell": {
         "found": "games/chess/index.html"
       },
@@ -225,12 +259,52 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png",
-        "placeholder": true
+        "found": "games/chess/thumb.svg",
+        "placeholder": false
       },
       "status": {
         "errors": false,
-        "warnings": true
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "chess.js",
+            "found": true,
+            "resolved": "games/chess/chess.js"
+          },
+          {
+            "requirement": "ai.js",
+            "found": true,
+            "resolved": "games/chess/ai.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/chess/net.js"
+          },
+          {
+            "requirement": "puzzles.js",
+            "found": true,
+            "resolved": "games/chess/puzzles.js"
+          },
+          {
+            "requirement": "ratings.js",
+            "found": true,
+            "resolved": "games/chess/ratings.js"
+          },
+          {
+            "requirement": "engine/rules.js",
+            "found": true,
+            "resolved": "games/chess/engine/rules.js"
+          },
+          {
+            "requirement": "engine/chess.min.js",
+            "found": true,
+            "resolved": "games/chess/engine/chess.min.js"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -238,16 +312,7 @@
       "title": "Chess 3D (Local)",
       "slug": "chess3d",
       "ok": true,
-      "issues": [
-        {
-          "message": "Thumbnail uses placeholder art",
-          "context": {
-            "thumbnail": "assets/placeholder-thumb.png",
-            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
-          },
-          "severity": "warning"
-        }
-      ],
+      "issues": [],
       "shell": {
         "found": "games/chess3d/index.html"
       },
@@ -261,12 +326,152 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png",
-        "placeholder": true
+        "found": "games/chess3d/thumb.svg",
+        "placeholder": false
       },
       "status": {
         "errors": false,
-        "warnings": true
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/chess3d/main.js"
+          },
+          {
+            "requirement": "board.js",
+            "found": true,
+            "resolved": "games/chess3d/board.js"
+          },
+          {
+            "requirement": "input.js",
+            "found": true,
+            "resolved": "games/chess3d/input.js"
+          },
+          {
+            "requirement": "pieces.js",
+            "found": true,
+            "resolved": "games/chess3d/pieces.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/chess3d/adapter.js"
+          }
+        ],
+        "globs": [
+          {
+            "pattern": "textures/*.js",
+            "matches": [
+              {
+                "relativeToShell": "textures/env.js",
+                "relativeToRoot": "games/chess3d/textures/env.js"
+              },
+              {
+                "relativeToShell": "textures/marble.js",
+                "relativeToRoot": "games/chess3d/textures/marble.js"
+              },
+              {
+                "relativeToShell": "textures/wood.js",
+                "relativeToRoot": "games/chess3d/textures/wood.js"
+              }
+            ]
+          },
+          {
+            "pattern": "ui/*.js",
+            "matches": [
+              {
+                "relativeToShell": "ui/cameraPresets.js",
+                "relativeToRoot": "games/chess3d/ui/cameraPresets.js"
+              },
+              {
+                "relativeToShell": "ui/clocks.js",
+                "relativeToRoot": "games/chess3d/ui/clocks.js"
+              },
+              {
+                "relativeToShell": "ui/coords.js",
+                "relativeToRoot": "games/chess3d/ui/coords.js"
+              },
+              {
+                "relativeToShell": "ui/evalBar.js",
+                "relativeToRoot": "games/chess3d/ui/evalBar.js"
+              },
+              {
+                "relativeToShell": "ui/highlight.js",
+                "relativeToRoot": "games/chess3d/ui/highlight.js"
+              },
+              {
+                "relativeToShell": "ui/hud.js",
+                "relativeToRoot": "games/chess3d/ui/hud.js"
+              },
+              {
+                "relativeToShell": "ui/lastMove.js",
+                "relativeToRoot": "games/chess3d/ui/lastMove.js"
+              },
+              {
+                "relativeToShell": "ui/modeBar.js",
+                "relativeToRoot": "games/chess3d/ui/modeBar.js"
+              },
+              {
+                "relativeToShell": "ui/movelist.js",
+                "relativeToRoot": "games/chess3d/ui/movelist.js"
+              },
+              {
+                "relativeToShell": "ui/promotionModal.js",
+                "relativeToRoot": "games/chess3d/ui/promotionModal.js"
+              },
+              {
+                "relativeToShell": "ui/themePicker.js",
+                "relativeToRoot": "games/chess3d/ui/themePicker.js"
+              }
+            ]
+          },
+          {
+            "pattern": "modes/*.js",
+            "matches": [
+              {
+                "relativeToShell": "modes/analysis.js",
+                "relativeToRoot": "games/chess3d/modes/analysis.js"
+              }
+            ]
+          },
+          {
+            "pattern": "ai/*.js",
+            "matches": [
+              {
+                "relativeToShell": "ai/ai.js",
+                "relativeToRoot": "games/chess3d/ai/ai.js"
+              },
+              {
+                "relativeToShell": "ai/simpleEngine.js",
+                "relativeToRoot": "games/chess3d/ai/simpleEngine.js"
+              },
+              {
+                "relativeToShell": "ai/stockfish.js",
+                "relativeToRoot": "games/chess3d/ai/stockfish.js"
+              },
+              {
+                "relativeToShell": "ai/stockfish.worker.js",
+                "relativeToRoot": "games/chess3d/ai/stockfish.worker.js"
+              }
+            ]
+          },
+          {
+            "pattern": "lib/*.js",
+            "matches": [
+              {
+                "relativeToShell": "lib/OrbitControls.js",
+                "relativeToRoot": "games/chess3d/lib/OrbitControls.js"
+              },
+              {
+                "relativeToShell": "lib/three.module.js",
+                "relativeToRoot": "games/chess3d/lib/three.module.js"
+              }
+            ]
+          }
+        ]
       }
     },
     {
@@ -274,16 +479,7 @@
       "title": "2048",
       "slug": "2048",
       "ok": true,
-      "issues": [
-        {
-          "message": "Thumbnail uses placeholder art",
-          "context": {
-            "thumbnail": "assets/placeholder-thumb.png",
-            "recommendation": "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
-          },
-          "severity": "warning"
-        }
-      ],
+      "issues": [],
       "shell": {
         "found": "games/2048/index.html"
       },
@@ -296,12 +492,47 @@
         ]
       },
       "thumbnail": {
-        "found": "assets/placeholder-thumb.png",
-        "placeholder": true
+        "found": "games/2048/thumb.svg",
+        "placeholder": false
       },
       "status": {
         "errors": false,
-        "warnings": true
+        "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "2048.js",
+            "found": true,
+            "resolved": "games/2048/2048.js"
+          },
+          {
+            "requirement": "engine.js",
+            "found": true,
+            "resolved": "games/2048/engine.js"
+          },
+          {
+            "requirement": "g2048.js",
+            "found": true,
+            "resolved": "games/2048/g2048.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/2048/net.js"
+          },
+          {
+            "requirement": "diag-adapter.js",
+            "found": true,
+            "resolved": "games/2048/diag-adapter.js"
+          },
+          {
+            "requirement": "assets/board-bg.png",
+            "found": true,
+            "resolved": "games/2048/assets/board-bg.png"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -330,6 +561,36 @@
       "status": {
         "errors": false,
         "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/asteroids/main.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/asteroids/net.js"
+          },
+          {
+            "requirement": "enemies.js",
+            "found": true,
+            "resolved": "games/asteroids/enemies.js"
+          },
+          {
+            "requirement": "diag-adapter.js",
+            "found": true,
+            "resolved": "games/asteroids/diag-adapter.js"
+          },
+          {
+            "requirement": "thumb.png",
+            "found": true,
+            "resolved": "games/asteroids/thumb.png"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -357,6 +618,36 @@
       "status": {
         "errors": false,
         "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/maze3d/main.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/maze3d/net.js"
+          },
+          {
+            "requirement": "generator.js",
+            "found": true,
+            "resolved": "games/maze3d/generator.js"
+          },
+          {
+            "requirement": "PointerLockControls.js",
+            "found": true,
+            "resolved": "games/maze3d/PointerLockControls.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/maze3d/adapter.js"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -396,6 +687,21 @@
             "requirement": "tiles.js",
             "found": true,
             "resolved": "games/platformer/tiles.js"
+          },
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/platformer/main.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/platformer/net.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/platformer/adapter.js"
           }
         ],
         "globs": [
@@ -441,6 +747,41 @@
       "status": {
         "errors": false,
         "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/runner/main.js"
+          },
+          {
+            "requirement": "editor.js",
+            "found": true,
+            "resolved": "games/runner/editor.js"
+          },
+          {
+            "requirement": "adapter.js",
+            "found": true,
+            "resolved": "games/runner/adapter.js"
+          },
+          {
+            "requirement": "levels.json",
+            "found": true,
+            "resolved": "games/runner/levels.json"
+          },
+          {
+            "requirement": "sample-level.json",
+            "found": true,
+            "resolved": "games/runner/sample-level.json"
+          },
+          {
+            "requirement": "thumb.png",
+            "found": true,
+            "resolved": "games/runner/thumb.png"
+          }
+        ],
+        "globs": []
       }
     },
     {
@@ -468,6 +809,31 @@
       "status": {
         "errors": false,
         "warnings": false
+      },
+      "requirements": {
+        "paths": [
+          {
+            "requirement": "main.js",
+            "found": true,
+            "resolved": "games/shooter/main.js"
+          },
+          {
+            "requirement": "net.js",
+            "found": true,
+            "resolved": "games/shooter/net.js"
+          },
+          {
+            "requirement": "diagnostics-adapter.js",
+            "found": true,
+            "resolved": "games/shooter/diagnostics-adapter.js"
+          },
+          {
+            "requirement": "thumb.png",
+            "found": true,
+            "resolved": "games/shooter/thumb.png"
+          }
+        ],
+        "globs": []
       }
     }
   ]

--- a/health/report.md
+++ b/health/report.md
@@ -1,11 +1,11 @@
 # Game Doctor Report
 
-Generated: 2025-10-07T20:23:32.951Z
+Generated: 2025-10-07T21:13:46.273Z
 
 - Total games: 12
 - Passing: 12
 - Failing: 0
-- With warnings: 6
+- With warnings: 0
 - Manifest version: 1
 - Manifest source: tools/reporters/game-doctor-manifest.json
 
@@ -24,80 +24,69 @@ Generated: 2025-10-07T20:23:32.951Z
 ## Snake
 
 - Slug: snake
-- Status: ⚠️ Review warnings
+- Status: ✅ Healthy
 - Shell: games/snake/index.html
-- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Thumbnail: games/snake/thumb.svg
 - Sprites checked: 1
 - Audio checked: 3
-- Issues:
-  - ⚠️ Warning: Thumbnail uses placeholder art
-    - thumbnail: "assets/placeholder-thumb.png"
-    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+- Manifest paths: all required paths found
+- Issues: none
 
 ## Tetris
 
 - Slug: tetris
-- Status: ⚠️ Review warnings
+- Status: ✅ Healthy
 - Shell: games/tetris/index.html
-- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Thumbnail: games/tetris/thumb.svg
 - Sprites checked: 4
 - Audio checked: 3
-- Issues:
-  - ⚠️ Warning: Thumbnail uses placeholder art
-    - thumbnail: "assets/placeholder-thumb.png"
-    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+- Manifest paths: all required paths found
+- Issues: none
 
 ## Breakout
 
 - Slug: breakout
-- Status: ⚠️ Review warnings
+- Status: ✅ Healthy
 - Shell: games/breakout/index.html
-- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Thumbnail: games/breakout/thumb.svg
 - Sprites checked: 3
 - Audio checked: 3
-- Issues:
-  - ⚠️ Warning: Thumbnail uses placeholder art
-    - thumbnail: "assets/placeholder-thumb.png"
-    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+- Manifest paths: all required paths found
+- Issues: none
 
 ## Chess (2D)
 
 - Slug: chess
-- Status: ⚠️ Review warnings
+- Status: ✅ Healthy
 - Shell: games/chess/index.html
-- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Thumbnail: games/chess/thumb.svg
 - Sprites checked: 2
 - Audio checked: 1
-- Issues:
-  - ⚠️ Warning: Thumbnail uses placeholder art
-    - thumbnail: "assets/placeholder-thumb.png"
-    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+- Manifest paths: all required paths found
+- Issues: none
 
 ## Chess 3D (Local)
 
 - Slug: chess3d
-- Status: ⚠️ Review warnings
+- Status: ✅ Healthy
 - Shell: games/chess3d/index.html
-- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Thumbnail: games/chess3d/thumb.svg
 - Sprites checked: 2
 - Audio checked: 1
-- Issues:
-  - ⚠️ Warning: Thumbnail uses placeholder art
-    - thumbnail: "assets/placeholder-thumb.png"
-    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+- Manifest paths: all required paths found
+- Manifest globs: all patterns matched files
+- Issues: none
 
 ## 2048
 
 - Slug: 2048
-- Status: ⚠️ Review warnings
+- Status: ✅ Healthy
 - Shell: games/2048/index.html
-- Thumbnail: assets/placeholder-thumb.png (⚠️ placeholder)
+- Thumbnail: games/2048/thumb.svg
 - Sprites checked: 1
 - Audio checked: 1
-- Issues:
-  - ⚠️ Warning: Thumbnail uses placeholder art
-    - thumbnail: "assets/placeholder-thumb.png"
-    - recommendation: "Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png"
+- Manifest paths: all required paths found
+- Issues: none
 
 ## Asteroids
 
@@ -107,6 +96,7 @@ Generated: 2025-10-07T20:23:32.951Z
 - Thumbnail: games/asteroids/thumb.png
 - Sprites checked: 1
 - Audio checked: 3
+- Manifest paths: all required paths found
 - Issues: none
 
 ## Maze 3D
@@ -117,6 +107,7 @@ Generated: 2025-10-07T20:23:32.951Z
 - Thumbnail: games/maze3d/thumb.png
 - Sprites checked: 2
 - Audio checked: 1
+- Manifest paths: all required paths found
 - Issues: none
 
 ## Pixel Platformer
@@ -139,6 +130,7 @@ Generated: 2025-10-07T20:23:32.951Z
 - Thumbnail: games/runner/thumb.png
 - Sprites checked: 1
 - Audio checked: 3
+- Manifest paths: all required paths found
 - Issues: none
 
 ## Alien Shooter
@@ -149,5 +141,6 @@ Generated: 2025-10-07T20:23:32.951Z
 - Thumbnail: games/shooter/thumb.png
 - Sprites checked: 1
 - Audio checked: 2
+- Manifest paths: all required paths found
 - Issues: none
 

--- a/tools/game-doctor.mjs
+++ b/tools/game-doctor.mjs
@@ -13,6 +13,7 @@ const REPORT_JSON = path.join(HEALTH_DIR, 'report.json');
 const REPORT_MD = path.join(HEALTH_DIR, 'report.md');
 const DEFAULT_BASELINE = path.join(HEALTH_DIR, 'baseline.json');
 const PLACEHOLDER_THUMB = 'assets/placeholder-thumb.png';
+const THUMB_EXTENSIONS = ['png', 'webp', 'jpg', 'jpeg', 'gif', 'svg'];
 
 const SEVERITY = {
   ERROR: 'error',
@@ -1312,11 +1313,14 @@ async function main() {
     let thumbnailFound = null;
     let thumbnailIsPlaceholder = false;
     if (slug) {
-      const thumbCandidates = [
-        path.join(ROOT, 'assets', 'thumbs', `${slug}.png`),
-        path.join(ROOT, 'games', slug, 'thumb.png'),
-        path.join(ROOT, PLACEHOLDER_THUMB),
-      ];
+      const thumbCandidates = [];
+      for (const ext of THUMB_EXTENSIONS) {
+        thumbCandidates.push(path.join(ROOT, 'assets', 'thumbs', `${slug}.${ext}`));
+      }
+      for (const ext of THUMB_EXTENSIONS) {
+        thumbCandidates.push(path.join(ROOT, 'games', slug, `thumb.${ext}`));
+      }
+      thumbCandidates.push(path.join(ROOT, PLACEHOLDER_THUMB));
       for (const candidate of thumbCandidates) {
         // eslint-disable-next-line no-await-in-loop
         if (await pathExists(candidate)) {
@@ -1339,7 +1343,8 @@ async function main() {
             'Thumbnail uses placeholder art',
             {
               thumbnail: thumbnailFound,
-              recommendation: 'Provide a bespoke thumbnail in assets/thumbs/<slug>.png or games/<slug>/thumb.png',
+              recommendation:
+                'Provide a bespoke thumbnail in assets/thumbs/<slug>.(png|svg) or games/<slug>/thumb.(png|svg)',
             },
             SEVERITY.WARNING,
           ),

--- a/tools/schemas/games.schema.json
+++ b/tools/schemas/games.schema.json
@@ -59,6 +59,10 @@
         "type": "string",
         "pattern": "^/games/[a-z0-9-]+/$"
       },
+      "thumbnail": {
+        "type": "string",
+        "pattern": "^/(assets|games)/.+"
+      },
       "firstFrame": {
         "type": "object",
         "required": ["sprites"],


### PR DESCRIPTION
## Summary
- replace the classic game PNG placeholders with inline SVG thumbnails for Snake, Tetris, Breakout, Chess, Chess 3D, and 2048
- allow Game Doctor and the games.json schema to accept multiple thumbnail formats and record the new SVG paths
- refresh the health baseline/report after supplying bespoke art

## Testing
- npm run doctor:quick

------
https://chatgpt.com/codex/tasks/task_e_68e58055840c8327ad166972a0f8257f