### PR TITLE
Handle compact catalog timestamps

### DIFF
--- a/js/catalog-utils.js
+++ b/js/catalog-utils.js
@@ -1,3 +1,20 @@
+function parseCompactDate(value){
+  if(value==null)return null;
+  const str=typeof value==='string'?value:value.toString();
+  const trimmed=str.trim();
+  if(!/^\d{8}$/.test(trimmed))return null;
+  const year=Number(trimmed.slice(0,4));
+  const month=Number(trimmed.slice(4,6));
+  const day=Number(trimmed.slice(6,8));
+  if(!Number.isFinite(year)||!Number.isFinite(month)||!Number.isFinite(day))return null;
+  if(month<1||month>12)return null;
+  if(day<1||day>31)return null;
+  const ms=Date.UTC(year,month-1,day);
+  const check=new Date(ms);
+  if(check.getUTCFullYear()!==year||check.getUTCMonth()!==month-1||check.getUTCDate()!==day)return null;
+  return ms;
+}
+
 export function normalizeTimestamp(value){
   if(value==null)return 0;
   if(value instanceof Date){
@@ -5,6 +22,10 @@ export function normalizeTimestamp(value){
     return Number.isNaN(t)?0:t;
   }
   if(typeof value==='number'){
+    const compact=parseCompactDate(value);
+    if(compact!=null)return compact;
+    const numericString=Number.isFinite(value)?Math.trunc(Math.abs(value)).toString():'';
+    if(/^\d{8}$/.test(numericString))return 0;
     if(!Number.isFinite(value))return 0;
     if(Math.abs(value)>=1e12)return value;
     if(Math.abs(value)>=1e9)return value*1000;
@@ -14,6 +35,8 @@ export function normalizeTimestamp(value){
   if(typeof value==='string'){
     const trimmed=value.trim();
     if(!trimmed)return 0;
+    const compact=parseCompactDate(trimmed);
+    if(compact!=null)return compact;
     const asNumber=Number(trimmed);
     if(Number.isFinite(asNumber))return normalizeTimestamp(asNumber);
     const parsed=Date.parse(trimmed);

--- a/tests/catalog.normalize-timestamp.test.js
+++ b/tests/catalog.normalize-timestamp.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTimestamp } from '../js/catalog-utils.js';
+
+const FEB_1_2024 = Date.UTC(2024, 1, 1);
+
+describe('normalizeTimestamp', () => {
+  it('parses compact YYYYMMDD strings', () => {
+    expect(normalizeTimestamp('20240201')).toBe(FEB_1_2024);
+  });
+
+  it('parses compact YYYYMMDD numbers', () => {
+    expect(normalizeTimestamp(20240201)).toBe(FEB_1_2024);
+  });
+
+  it('ignores invalid compact dates', () => {
+    expect(normalizeTimestamp('20240231')).toBe(0);
+    expect(normalizeTimestamp(20240231)).toBe(0);
+  });
+
+  it('preserves behaviour for epoch seconds', () => {
+    const epochSeconds = 1706745600; // 2024-02-01T00:00:00Z
+    expect(normalizeTimestamp(epochSeconds)).toBe(epochSeconds * 1000);
+  });
+});


### PR DESCRIPTION
## Summary
- add compact YYYYMMDD parsing to `normalizeTimestamp` so release dates map to valid ms values
- guard against invalid compact dates and exercise the behaviour with unit tests

## Testing
- npm run health
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e58973f36c8327a5e436fa02fdb11b