### PR TITLE
Add code health score baseline support

### DIFF
--- a/health/code-baseline.json
+++ b/health/code-baseline.json
@@ -1,0 +1,7 @@
+{
+  "generatedAt": "2025-10-07T22:56:02.198Z",
+  "score": {
+    "value": 100,
+    "breakdown": []
+  }
+}


### PR DESCRIPTION
## Summary
- add code health baseline storage and scoring helpers to Code Doctor
- surface current score, baseline comparison, and update messaging in generated reports and console output
- seed an initial code health baseline file so future runs can compute diffs

## Testing
- npm run code:doctor
- CODE_DOCTOR_UPDATE_BASELINE=1 npm run code:doctor

------
https://chatgpt.com/codex/tasks/task_e_68e59938c22c832786bdf384837a35d0