### PR TITLE
Improve Game Doctor failure diagnostics

### DIFF
--- a/.github/workflows/game-doctor.yml
+++ b/.github/workflows/game-doctor.yml
@@ -36,15 +36,43 @@ jobs:
         run: npm ci
 
       - name: Run Game Doctor tests
-        run: npm run test:doctor
+        id: game_doctor_tests
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p health
+          npm run test:doctor 2>&1 | tee health/game-doctor-tests.log
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          echo "log_path=health/game-doctor-tests.log" >> "$GITHUB_OUTPUT"
+          if [ "$status" -ne 0 ]; then
+            echo "Game Doctor tests failed with exit code $status" >&2
+          fi
+          exit 0
 
       - name: Run Game Doctor
-        run: node tools/game-doctor.mjs --strict --baseline=health/baseline.json
+        id: run_game_doctor
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p health
+          node tools/game-doctor.mjs --strict --baseline=health/baseline.json 2>&1 | tee health/game-doctor.log
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          echo "log_path=health/game-doctor.log" >> "$GITHUB_OUTPUT"
+          if [ "$status" -ne 0 ]; then
+            echo "Game Doctor run failed with exit code $status" >&2
+          fi
+          exit 0
 
       - name: Comment Game Doctor results
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GAME_DOCTOR_TESTS_EXIT_CODE: ${{ steps.game_doctor_tests.outputs.exit_code }}
+          GAME_DOCTOR_EXIT_CODE: ${{ steps.run_game_doctor.outputs.exit_code }}
+          GAME_DOCTOR_TESTS_LOG: ${{ steps.game_doctor_tests.outputs.log_path }}
+          GAME_DOCTOR_LOG: ${{ steps.run_game_doctor.outputs.log_path }}
         run: node tools/comment-game-doctor.mjs
 
       - name: Upload Game Doctor report
@@ -151,3 +179,19 @@ jobs:
                 body: commentBody,
               });
             }
+
+      - name: Fail workflow if Game Doctor checks failed
+        if: >-
+          ${{ always() && (steps.game_doctor_tests.outputs.exit_code != '0' || steps.run_game_doctor.outputs.exit_code != '0') }}
+        env:
+          TEST_EXIT_CODE: ${{ steps.game_doctor_tests.outputs.exit_code }}
+          DOCTOR_EXIT_CODE: ${{ steps.run_game_doctor.outputs.exit_code }}
+        run: |
+          echo "Game Doctor checks encountered failures:" >&2
+          if [ "${TEST_EXIT_CODE}" != '0' ]; then
+            echo "- npm run test:doctor exited with ${TEST_EXIT_CODE}" >&2
+          fi
+          if [ "${DOCTOR_EXIT_CODE}" != '0' ]; then
+            echo "- node tools/game-doctor.mjs exited with ${DOCTOR_EXIT_CODE}" >&2
+          fi
+          exit 1

--- a/tools/comment-game-doctor.mjs
+++ b/tools/comment-game-doctor.mjs
@@ -7,6 +7,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const REPORT_MD_PATH = path.join(ROOT, 'health', 'report.md');
 const REPORT_JSON_PATH = path.join(ROOT, 'health', 'report.json');
+const DEFAULT_TEST_LOG_PATH = path.join('health', 'game-doctor-tests.log');
+const DEFAULT_RUN_LOG_PATH = path.join('health', 'game-doctor.log');
+const MAX_LOG_CHARACTERS = 60000;
 
 function log(message) {
   console.log(`[comment-game-doctor] ${message}`);
@@ -22,7 +25,7 @@ async function readReportMarkdown() {
     return markdown.trim();
   } catch (error) {
     if (error.code === 'ENOENT') {
-      warn(`Skipping comment because ${path.relative(ROOT, REPORT_MD_PATH)} is missing.`);
+      warn(`Game Doctor report markdown missing at ${path.relative(ROOT, REPORT_MD_PATH)}.`);
       return null;
     }
     throw error;
@@ -44,6 +47,80 @@ async function readSummaryLine() {
     warn(`Unable to read summary from ${path.relative(ROOT, REPORT_JSON_PATH)}: ${error.message}`);
     return null;
   }
+}
+
+function parseExitCode(raw) {
+  if (raw == null || raw === '') {
+    return null;
+  }
+  const value = Number.parseInt(String(raw), 10);
+  if (Number.isNaN(value)) {
+    return null;
+  }
+  return value;
+}
+
+function resolveLogPath(rawPath, fallbackRelative) {
+  const candidate = rawPath && rawPath.trim().length > 0 ? rawPath.trim() : fallbackRelative;
+  if (!candidate) {
+    return null;
+  }
+  return path.isAbsolute(candidate) ? candidate : path.join(ROOT, candidate);
+}
+
+async function loadLogDetails(label, rawPath) {
+  if (!rawPath) {
+    return { missing: true, relativePath: null };
+  }
+  const relativePath = path.relative(ROOT, rawPath);
+  try {
+    const raw = await fs.readFile(rawPath, 'utf8');
+    let content = raw.replace(/\s+$/u, '');
+    let truncated = false;
+    if (content.length > MAX_LOG_CHARACTERS) {
+      truncated = true;
+      content = content.slice(content.length - MAX_LOG_CHARACTERS);
+      const firstNewline = content.indexOf('\n');
+      if (firstNewline > 0) {
+        content = content.slice(firstNewline + 1);
+      }
+      content = content.replace(/^\s+/u, '');
+    }
+    return { content, truncated, relativePath };
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      warn(`Log for ${label} not found at ${relativePath}.`);
+      return { missing: true, relativePath };
+    }
+    warn(`Unable to read log for ${label} at ${relativePath}: ${error.message}`);
+    return { missing: true, relativePath };
+  }
+}
+
+async function collectFailureDetails() {
+  const failures = [];
+  const descriptors = [
+    {
+      label: 'Game Doctor tests',
+      exitCode: parseExitCode(process.env.GAME_DOCTOR_TESTS_EXIT_CODE),
+      rawPath: resolveLogPath(process.env.GAME_DOCTOR_TESTS_LOG, DEFAULT_TEST_LOG_PATH),
+    },
+    {
+      label: 'Game Doctor run',
+      exitCode: parseExitCode(process.env.GAME_DOCTOR_EXIT_CODE),
+      rawPath: resolveLogPath(process.env.GAME_DOCTOR_LOG, DEFAULT_RUN_LOG_PATH),
+    },
+  ];
+
+  for (const descriptor of descriptors) {
+    if (descriptor.exitCode == null || descriptor.exitCode === 0) {
+      continue;
+    }
+    const log = await loadLogDetails(descriptor.label, descriptor.rawPath);
+    failures.push({ label: descriptor.label, exitCode: descriptor.exitCode, log });
+  }
+
+  return failures;
 }
 
 async function loadPullRequestContext() {
@@ -135,17 +212,59 @@ async function main() {
   }
 
   const markdown = await readReportMarkdown();
-  if (!markdown) {
+  const summary = await readSummaryLine();
+  const failures = await collectFailureDetails();
+
+  const hasReport = Boolean(markdown);
+  let summaryLine = summary;
+  if (!summaryLine) {
+    if (failures.length > 0) {
+      summaryLine = '⚠️ Game Doctor encountered failures. See logs below.';
+    } else if (hasReport) {
+      summaryLine = '✅ Game Doctor report generated. See details below.';
+    } else {
+      summaryLine = '⚠️ Game Doctor report was not generated.';
+    }
+  }
+
+  if (!hasReport && failures.length === 0 && !summaryLine) {
+    warn('Skipping comment because no report or failure information is available.');
     return;
   }
 
-  const summary = await readSummaryLine();
-
   const sections = ['### 🩺 Game Doctor results'];
-  if (summary) {
-    sections.push('', summary);
+  if (summaryLine) {
+    sections.push('', summaryLine);
   }
-  sections.push('', '<details>', '<summary>View full report</summary>', '', '```markdown', markdown, '```', '', '</details>');
+
+  if (failures.length > 0) {
+    sections.push('', '#### ❌ Failure details');
+    for (const failure of failures) {
+      sections.push('', `**${failure.label}** exited with code ${failure.exitCode}.`);
+      if (failure.log?.content) {
+        sections.push(
+          '',
+          '<details>',
+          `<summary>View ${failure.label.toLowerCase()} log</summary>`,
+          '',
+          '```text',
+          failure.log.content,
+          '```',
+        );
+        if (failure.log.truncated) {
+          sections.push('', `_Log truncated to the last ${MAX_LOG_CHARACTERS.toLocaleString('en-US')} characters._`);
+        }
+        sections.push('', '</details>');
+      } else if (failure.log?.missing) {
+        const relativePath = failure.log.relativePath ?? '(unknown path)';
+        sections.push('', `_Log file ${relativePath} is not available._`);
+      }
+    }
+  }
+
+  if (hasReport) {
+    sections.push('', '<details>', '<summary>View full report</summary>', '', '```markdown', markdown, '```', '', '</details>');
+  }
 
   const commentBody = sections.join('\n');
   try {


### PR DESCRIPTION
## Summary
- capture Game Doctor test and run output to log files while preserving their exit codes
- enhance the Game Doctor PR comment to surface failure logs and fall back gracefully when reports are missing
- keep the workflow failing after comments by checking the recorded exit codes at the end of the job

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68e5e082dc4083279ff8fd4c5e575a8d