### PR TITLE
Remove unused bindings from game modules

### DIFF
--- a/games/asteroids/main.js
+++ b/games/asteroids/main.js
@@ -373,7 +373,6 @@ const bootTracker = createBootTracker(SLUG);
 const {
   milestone: recordMilestone,
   rafTick: recordRafTick,
-  rafActive: setRafActive,
   warnCanvas: recordCanvasWarning,
   recordCanvasSample,
   updateReadyState,
@@ -679,34 +678,6 @@ function createAudio(src, volume = 0.6) {
       // ignore playback failures (likely due to user gesture requirements)
     }
   };
-}
-
-function loadImage(src) {
-  if (typeof Image === 'undefined') return null;
-  const image = new Image();
-  image.decoding = 'async';
-  image.loading = 'eager';
-  image.src = src;
-  return image;
-}
-
-function createTintedSprite(image, color) {
-  if (typeof document === 'undefined') return null;
-  const width = image.naturalWidth || image.width || 0;
-  const height = image.naturalHeight || image.height || 0;
-  if (!width || !height) return null;
-  const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return null;
-  ctx.clearRect(0, 0, width, height);
-  ctx.drawImage(image, 0, 0, width, height);
-  ctx.globalCompositeOperation = 'source-in';
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-  ctx.globalCompositeOperation = 'source-over';
-  return canvas;
 }
 
 class AsteroidsGame {

--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1,6 +1,6 @@
 import * as net from './net.js';
 import { pushEvent } from '/games/common/diag-adapter.js';
-import { drawTileSprite, getTilePattern, getSpriteFrame, preloadTileTextures } from '../../shared/render/tileTextures.js';
+import { drawTileSprite, getTilePattern, preloadTileTextures } from '../../shared/render/tileTextures.js';
 import { loadStrip } from '../../shared/assets.js';
 import { play as playSfx, setPaused as setAudioPaused } from '../../shared/juice/audio.js';
 import { tiles, TILE } from './tiles.js';
@@ -397,7 +397,6 @@ const PLAYER_SPRITE_SPECS = {
   jump: { src: '/assets/sprites/player/platformer_jump.png', frameWidth: 16, frameHeight: 16, frames: 1 },
 };
 
-const COIN_SPRITE = tiles['2']?.sprite ?? null;
 const GOAL_SPRITE = tiles['3']?.sprite ?? null;
 function normKey(key) {
   if (key === ' ') return 'space';


### PR DESCRIPTION
## Summary
- drop the unused boot tracker alias in the asteroids game module
- remove unused image helper functions from asteroids
- eliminate unused tile texture import and coin sprite constant in the platformer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e84dcb808327b59d1d79f8bcf212