### PR TITLE
Ensure shell pause keeps manual pauses intact

### DIFF
--- a/games/pong/pong.js
+++ b/games/pong/pong.js
@@ -1222,7 +1222,7 @@ import "./pauseOverlay.js";
   }
 
   function pauseForShell(){
-    if(state.over) return;
+    if(state.over || state.paused) return;
     setPaused(true, "shell");
   }
   function resumeFromShell(){


### PR DESCRIPTION
## Summary
- avoid re-applying the shell pause when the game is already paused
- preserve manual pause state so shell resume events do not unpause gameplay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e9eced888327826e11f34f0c19b7