### PR TITLE
Fix gravity timer handling for automatic drops

### DIFF
--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -1268,7 +1268,9 @@ function drop(manual=false){
     updateBest();
     syncScoreDisplay();
   }
-  gravityTimer=0;
+  if(manual){
+    gravityTimer=0;
+  }
   onPieceMoved();
   return 'move';
 }


### PR DESCRIPTION
## Summary
- guard the gravity timer reset in `drop()` so automatic gravity ticks keep their accumulated interval

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e5e9ee61508327b7204070f64eaa47