### PR TITLE
Fix fall detection trigger when player is clamped

### DIFF
--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -1715,7 +1715,7 @@ export async function boot() {
       return;
     }
 
-    if (localPlayer.y > worldBounds.height + TILE * 4) {
+    if (localPlayer.y >= worldBounds.height + TILE * 4) {
       triggerGameOver(
         'Game Over',
         `You fell after collecting ${localPlayer.collected}/${coins.length} coins in ${secondsElapsed().toFixed(1)}s.`,


### PR DESCRIPTION
## Summary
- allow the fall game-over check to trigger even after the position clamp

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e9f153608327947d06e0910f2f88