### PR TITLE
Fix diagnostics adapter readiness initialization order

### DIFF
--- a/games/common/diag-core.js
+++ b/games/common/diag-core.js
@@ -28,6 +28,12 @@
     { id: "env", label: "Env" },
   ];
 
+  const ADAPTER_READY_TIMEOUT_MS = 5000;
+  const ADAPTER_READY_POLL_INTERVAL_MS = 50;
+  const adapterReadyWaiters = [];
+  let adapterReadyTimer = null;
+  let adapterReadyDeadline = 0;
+
   const state = {
     store: reportStore,
     maxLogs: reportStore?.config?.maxConsole || 500,
@@ -295,12 +301,6 @@
       return "";
     }
   }
-
-  const ADAPTER_READY_TIMEOUT_MS = 5000;
-  const ADAPTER_READY_POLL_INTERVAL_MS = 50;
-  const adapterReadyWaiters = [];
-  let adapterReadyTimer = null;
-  let adapterReadyDeadline = 0;
 
   function ensureDiagnosticsAdapterModule(){
     const resolved = resolveDiagnosticsAdapterModule();


### PR DESCRIPTION
## Summary
- move diagnostics adapter readiness state initialization ahead of early adapter hooks to avoid temporal dead zone errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5ec16d9cc8327848d958bb4263c45