### PR TITLE
Fix Maze3D diagnostics adapter initialization order

### DIFF
--- a/games/common/diag-core.js
+++ b/games/common/diag-core.js
@@ -28,6 +28,12 @@
     { id: "env", label: "Env" },
   ];
 
+  const ADAPTER_READY_TIMEOUT_MS = 5000;
+  const ADAPTER_READY_POLL_INTERVAL_MS = 50;
+  const adapterReadyWaiters = [];
+  let adapterReadyTimer = null;
+  let adapterReadyDeadline = 0;
+
   const state = {
     store: reportStore,
     maxLogs: reportStore?.config?.maxConsole || 500,
@@ -295,12 +301,6 @@
       return "";
     }
   }
-
-  const ADAPTER_READY_TIMEOUT_MS = 5000;
-  const ADAPTER_READY_POLL_INTERVAL_MS = 50;
-  const adapterReadyWaiters = [];
-  let adapterReadyTimer = null;
-  let adapterReadyDeadline = 0;
 
   function ensureDiagnosticsAdapterModule(){
     const resolved = resolveDiagnosticsAdapterModule();


### PR DESCRIPTION
## Summary
- declare diagnostics adapter readiness tracking variables before they are used during initialization
- prevent ReferenceError when Maze3D diagnostics module queues readiness callbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ec6841d883278571634f67759bbc