### PR TITLE
Improve code doctor circular dependency reporting

### DIFF
--- a/tests/code-doctor.circular.test.mjs
+++ b/tests/code-doctor.circular.test.mjs
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createCodeDoctorFixture } from './fixtures/code-doctor-fixture.mjs';
+
+describe('tools/code-doctor.mjs', () => {
+  let fixture;
+
+  afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = null;
+    }
+  });
+
+  it('builds a graph of relative imports and reports shortest cycle paths', async () => {
+    fixture = await createCodeDoctorFixture('circular');
+
+    await fixture.writeJson('package.json', {
+      name: 'code-doctor-circular-fixture',
+      version: '1.0.0',
+    });
+
+    await fixture.writeFile(
+      'src/a.js',
+      ["import './b.js';", "import './d.js';", ''].join('\n'),
+    );
+    await fixture.writeFile('src/b.js', "import './c.js';\n");
+    await fixture.writeFile('src/c.js', "import './a.js';\n");
+    await fixture.writeFile('src/d.js', "import './e.js';\n");
+    await fixture.writeFile('src/e.js', "import './f.js';\n");
+    await fixture.writeFile('src/f.js', "import './a.js';\n");
+    await fixture.writeFile('src/self.js', "import './self.js';\n");
+
+    const result = await fixture.runDoctor();
+
+    expect(result.code).toBe(1);
+    expect(result.stderr.trim()).toBe('');
+
+    const report = await fixture.readJson('health/code-report.json');
+    const circular = report.checks.circular;
+
+    expect(circular.status).toBe('failed');
+    expect(circular.summary).toContain('2 circular dependencies detected');
+
+    expect(circular.graph['src/a.js']).toEqual(['src/b.js', 'src/d.js']);
+    expect(circular.graph['src/b.js']).toEqual(['src/c.js']);
+    expect(circular.graph['src/c.js']).toEqual(['src/a.js']);
+    expect(circular.graph['src/self.js']).toEqual(['src/self.js']);
+
+    expect(circular.cycles).toEqual([
+      ['src/a.js', 'src/b.js', 'src/c.js', 'src/a.js'],
+      ['src/self.js', 'src/self.js'],
+    ]);
+
+    const messages = circular.issues.map((issue) => issue.message);
+    expect(messages).toContain('src/a.js -> src/b.js -> src/c.js -> src/a.js');
+    expect(messages).toContain('src/self.js -> src/self.js');
+    expect(messages).not.toContain('src/a.js -> src/d.js -> src/e.js -> src/f.js -> src/a.js');
+  });
+});

--- a/tests/fixtures/code-doctor-fixture.mjs
+++ b/tests/fixtures/code-doctor-fixture.mjs
@@ -1,0 +1,87 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+class CodeDoctorFixture {
+  constructor(root) {
+    this.root = root;
+    this.codeDoctorPath = this.path('tools/code-doctor.mjs');
+  }
+
+  path(relativePath) {
+    return path.join(this.root, relativePath);
+  }
+
+  async writeFile(relativePath, contents = '') {
+    const absolutePath = this.path(relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, contents);
+  }
+
+  async writeJson(relativePath, data) {
+    await this.writeFile(relativePath, `${JSON.stringify(data, null, 2)}\n`);
+  }
+
+  async readJson(relativePath) {
+    const absolutePath = this.path(relativePath);
+    const raw = await fs.readFile(absolutePath, 'utf8');
+    return JSON.parse(raw);
+  }
+
+  async runDoctor(args = [], { env = {} } = {}) {
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [this.codeDoctorPath, ...args], {
+        cwd: this.root,
+        env: { ...process.env, ...env },
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+
+      child.on('error', reject);
+      child.on('close', (code) => {
+        resolve({ code, stdout, stderr });
+      });
+    });
+  }
+
+  async cleanup() {
+    await fs.rm(this.root, { recursive: true, force: true });
+  }
+}
+
+export async function createCodeDoctorFixture(name = 'fixture') {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), `code-doctor-${name}-`));
+  const fixture = new CodeDoctorFixture(tmpRoot);
+
+  await fs.mkdir(fixture.path('tools'), { recursive: true });
+  await fs.mkdir(fixture.path('health'), { recursive: true });
+
+  await fs.copyFile(path.join(REPO_ROOT, 'tools', 'code-doctor.mjs'), fixture.path('tools/code-doctor.mjs'));
+
+  try {
+    await fs.symlink(path.join(REPO_ROOT, 'node_modules'), fixture.path('node_modules'), 'dir');
+  } catch (error) {
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  }
+
+  return fixture;
+}


### PR DESCRIPTION
## Summary
- build a normalized graph of relative imports and compute shortest cycles per strongly connected component
- include bare import specifiers in dependency analysis and expose the graph/cycle data in the circular check results
- add a code doctor fixture and regression test that validates the graph output and shortest-cycle reporting

## Testing
- npx vitest run tests/code-doctor.circular.test.mjs
- npm run test:doctor

------
https://chatgpt.com/codex/tasks/task_e_68e5ed2198008327a519f7e55a22eadd