### PR TITLE
Fix diagnostics core constants and shooter wave syntax

### DIFF
--- a/games/common/diag-core.js
+++ b/games/common/diag-core.js
@@ -150,12 +150,6 @@
     { id: "env", label: "Env" },
   ];
 
-  const ADAPTER_READY_TIMEOUT_MS = 5000;
-  const ADAPTER_READY_POLL_INTERVAL_MS = 50;
-  const adapterReadyWaiters = [];
-  let adapterReadyTimer = null;
-  let adapterReadyDeadline = 0;
-
   const state = {
     store: reportStore,
     maxLogs: reportStore?.config?.maxConsole || 500,

--- a/games/shooter/main.js
+++ b/games/shooter/main.js
@@ -1105,7 +1105,7 @@ export function boot() {
         spawnEnemy(wave.boss.type || 'overseer', { x: W - 120, y: H / 2 });
         wave.boss.spawned = true;
       }
-      if (!wave.boss && wave.spawns.every(spawn => spawn.spawned >= Math.max(1, Math.floor(spawn.config.count || 1))))) {
+      if (!wave.boss && wave.spawns.every(spawn => spawn.spawned >= Math.max(1, Math.floor(spawn.config.count || 1)))) {
         if (!enemies.some(enemy => !enemy.dead)) {
           finished = true;
         } else {


### PR DESCRIPTION
## Summary
- define the diagnostics adapter timing constants once at the top of `diag-core.js`
- remove the redundant redeclaration block that conflicted with the earlier state variables
- correct the shooter wave completion check by removing an extra closing parenthesis

## Testing
- node --check games/common/diag-core.js
- node --check games/shooter/main.js

------
https://chatgpt.com/codex/tasks/task_e_68e5f00d1b5883279864b8ec2d0cca36