### PR TITLE
Fix router click interception for modified link gestures

### DIFF
--- a/scripts/router.js
+++ b/scripts/router.js
@@ -4,14 +4,39 @@ export class Router {
     this.routes = [];
     window.addEventListener('popstate', () => this.resolve(location.pathname, { mode: 'pop', visited: new Set() }));
     document.addEventListener('click', e => {
-      const a = e.target.closest('a');
-      if (a && a instanceof HTMLAnchorElement && a.origin === location.origin) {
-        const href = a.getAttribute('href');
-        if (href && href.startsWith('/')) {
-          e.preventDefault();
-          this.navigate(href);
-        }
+      if (e.defaultPrevented) {
+        return;
       }
+      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+      }
+      const target = e.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      const a = target.closest('a');
+      if (!a || !(a instanceof HTMLAnchorElement)) {
+        return;
+      }
+      if (a.target && a.target !== '_self') {
+        return;
+      }
+      if (a.hasAttribute('download')) {
+        return;
+      }
+      const rel = a.getAttribute('rel');
+      if (rel && /\bexternal\b/i.test(rel)) {
+        return;
+      }
+      if (a.origin !== location.origin) {
+        return;
+      }
+      const href = a.getAttribute('href');
+      if (!href || !href.startsWith('/')) {
+        return;
+      }
+      e.preventDefault();
+      this.navigate(href);
     });
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -24,18 +24,47 @@ export class Router {
     this.outlet = outlet;
     window.addEventListener('popstate', () => this.resolve(location.pathname, { mode: 'pop', visited: new Set() }));
     document.addEventListener('click', e => {
+      if (e.defaultPrevented) {
+        return;
+      }
+      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+      }
+
       const target = e.target;
       if (!(target instanceof Element)) {
         return;
       }
+
       const a = target.closest('a');
-      if (a && a instanceof HTMLAnchorElement && a.origin === location.origin) {
-        const href = a.getAttribute('href');
-        if (href && href.startsWith('/')) {
-          e.preventDefault();
-          this.navigate(href);
-        }
+      if (!a || !(a instanceof HTMLAnchorElement)) {
+        return;
       }
+
+      if (a.target && a.target !== '_self') {
+        return;
+      }
+
+      if (a.hasAttribute('download')) {
+        return;
+      }
+
+      const rel = a.getAttribute('rel');
+      if (rel && /\bexternal\b/i.test(rel)) {
+        return;
+      }
+
+      if (a.origin !== location.origin) {
+        return;
+      }
+
+      const href = a.getAttribute('href');
+      if (!href || !href.startsWith('/')) {
+        return;
+      }
+
+      e.preventDefault();
+      this.navigate(href);
     });
   }
 

--- a/tests/router.guard.test.js
+++ b/tests/router.guard.test.js
@@ -112,4 +112,42 @@ describe('Router guard navigation', () => {
     replaceSpy.mockRestore();
     history.replaceState({}, '', originalPathname);
   });
+
+  test('router does not hijack modified or external link clicks', async () => {
+    const outlet = document.createElement('div');
+    const router = new Router(outlet);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue();
+
+    const anchor = document.createElement('a');
+    anchor.href = '/games';
+    document.body.appendChild(anchor);
+
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, metaKey: true }));
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, ctrlKey: true }));
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, shiftKey: true }));
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, altKey: true }));
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 1 }));
+
+    anchor.target = '_blank';
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    anchor.removeAttribute('target');
+
+    anchor.setAttribute('download', 'file');
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    anchor.removeAttribute('download');
+
+    anchor.setAttribute('rel', 'external noopener');
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    anchor.setAttribute('rel', 'noopener');
+
+    const child = document.createElement('span');
+    anchor.appendChild(child);
+    child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(navigateSpy).toHaveBeenCalledWith('/games');
+
+    anchor.remove();
+    navigateSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- prevent the Router from hijacking modified/external link clicks and respect anchor attributes
- guard against non-element click targets before calling closest()
- add a regression test covering the router click interception edge cases

## Testing
- npx vitest run tests/router.guard.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5f125748883278e816c5b2cfecf49