### PR TITLE
Add animated gradient background to Pong

### DIFF
--- a/games/pong/pong.css
+++ b/games/pong/pong.css
@@ -44,7 +44,8 @@
 
 * { box-sizing: border-box; }
 .pong-root{background:var(--pong-bg); color:var(--pong-fg); margin:0; min-height:100svh; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";}
-.pong-app{display:grid; grid-template-rows:auto 1fr auto; min-height:100svh;}
+.pong-bg-canvas{position:fixed; inset:0; width:100vw; height:100vh; pointer-events:none; display:block; z-index:0;}
+.pong-app{display:grid; grid-template-rows:auto 1fr auto; min-height:100svh; position:relative; z-index:1;}
 
 .pong-bar{display:flex; align-items:center; gap:.5rem; padding:.75rem 1rem; border-bottom:1px solid #1b2533;}
 .pong-title{font-weight:800; letter-spacing:.3px;}


### PR DESCRIPTION
## Summary
- add an animated full-screen gradient canvas with a subtle vignette behind Pong
- resize and animate the background layer each frame while respecting reduced motion
- layer styling updates to ensure the gradient sits behind the app layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f2634c908327a3f482fc1aa92c4a