### PR TITLE
feat: add Snake HUD panels and background themes

### DIFF
--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -52,48 +52,228 @@
     }
     .hud {
       position: fixed;
-      top: 10px;
+      top: 12px;
       left: 50%;
       transform: translateX(-50%);
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      align-items: center;
-      padding: 10px 12px;
-      background: rgba(11, 17, 42, 0.75);
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 12px;
+      padding: 16px 18px;
+      width: min(100vw - 24px, 960px);
+      background: rgba(11, 17, 42, 0.78);
       border: 1px solid var(--border);
-      border-radius: 14px;
-      box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+      border-radius: 18px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(8px);
+      z-index: 5;
     }
-    .hud label,
-    .hud button,
-    .hud select {
-      font-size: 14px;
+    .hud-panel {
+      background: rgba(17, 23, 53, 0.75);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      padding: 12px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      min-width: 0;
+    }
+    .hud-panel__header {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .hud-panel__title {
+      margin: 0;
+      font-size: 13px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+    .hud-panel__subtitle {
+      margin: 0;
+      font-size: 12px;
+      color: var(--muted);
+      line-height: 1.4;
+    }
+    .hud-panel__body {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+    .hud-field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 12px;
+    }
+    .hud-field select {
+      appearance: none;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 10px;
+      padding: 6px 10px;
+      color: var(--fg);
+      font-weight: 600;
+    }
+    .hud-field--toggle {
+      flex-direction: row;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      color: var(--fg);
+    }
+    .hud-field--toggle input[type="checkbox"] {
+      margin: 0;
+      width: auto;
+      height: auto;
+      accent-color: var(--accent);
+    }
+    .hud-missionList {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .hud-mission {
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 12px;
+      padding: 8px 10px;
+      transition: border-color 0.2s ease, background 0.2s ease;
+    }
+    .hud-mission[data-complete="true"] {
+      border-color: rgba(34, 197, 94, 0.65);
+      background: rgba(34, 197, 94, 0.12);
+    }
+    .hud-mission[data-disabled="true"] {
+      opacity: 0.6;
+    }
+    .hud-mission__name {
+      margin: 0 0 4px 0;
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--fg);
+    }
+    .hud-mission__desc {
+      margin: 0 0 6px 0;
+      font-size: 12px;
+      color: var(--muted);
+      line-height: 1.4;
+    }
+    .hud-mission__meter {
+      position: relative;
+      height: 6px;
+      background: rgba(255, 255, 255, 0.12);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+    .hud-mission__meter span {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, var(--accent), #a855f7);
+    }
+    .hud-mission__status {
+      margin: 6px 0 0 0;
+      font-size: 11px;
+      color: var(--muted);
+    }
+    .hud-meter {
+      font-size: 24px;
+      font-weight: 700;
+      color: var(--accent);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      transition: color 0.2s ease;
+    }
+    .hud-meter[data-active="false"] {
+      color: var(--muted);
+    }
+    .hud-meter__timer {
+      font-size: 12px;
+      color: var(--muted);
+    }
+    .hud-diagnostics {
+      display: none;
+      font-size: 12px;
+      line-height: 1.5;
+      background: rgba(8, 13, 34, 0.82);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 12px;
+      padding: 8px 10px;
+      min-height: 80px;
+    }
+    .hud-diagnostics[data-level="warn"] {
+      border-color: rgba(251, 191, 36, 0.65);
+    }
+    .hud-diagnostics[data-level="error"] {
+      border-color: rgba(248, 113, 113, 0.7);
+      color: #fecaca;
+    }
+    .hud-logList {
+      display: none;
+      font-size: 11px;
+      line-height: 1.4;
+      background: rgba(8, 13, 34, 0.82);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 12px;
+      padding: 8px 10px;
+      max-height: 160px;
+      overflow-y: auto;
+    }
+    .hud-log {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      column-gap: 8px;
+      row-gap: 2px;
+      margin-bottom: 6px;
+    }
+    .hud-log:last-child {
+      margin-bottom: 0;
+    }
+    .hud-log__time {
+      font-variant-numeric: tabular-nums;
+      color: var(--muted);
+      font-size: 11px;
+    }
+    .hud-log__message {
+      font-size: 12px;
       font-weight: 600;
       color: var(--fg);
     }
-    .hud select,
-    .hud button,
-    .hud input[type="checkbox"] {
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 4px 8px;
+    .hud-log__detail {
+      grid-column: span 2;
+      font-size: 11px;
+      color: var(--muted);
+    }
+    .hud-log--warn .hud-log__message {
+      color: #fbbf24;
+    }
+    .hud-log--error .hud-log__message {
+      color: #f87171;
+    }
+    .hud-dailyList {
+      margin: 0;
+      padding-left: 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
       color: var(--fg);
+      font-size: 13px;
     }
-    .hud input[type="checkbox"] {
-      width: auto;
-      margin-right: 4px;
-      transform: translateY(1px);
-    }
-    @media (max-width: 600px) {
+    @media (max-width: 720px) {
       .hud {
         top: auto;
         bottom: 12px;
         left: 12px;
-        transform: none;
         right: 12px;
-        justify-content: center;
+        transform: none;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        padding: 14px;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- replace the Snake HUD with modular panels for controls, skins, missions, combo meter, and diagnostics
- add unlockable parallax background themes with configurable scroll speeds and overlays
- feed boot watchdog logs into an in-game diagnostics toggle and surface combo-based mission tracking

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68a5ab8c083278916c25f478f8ac5