### PR TITLE
Remove unused code in 2048 and Maze3D

### DIFF
--- a/games/2048/g2048.js
+++ b/games/2048/g2048.js
@@ -1083,21 +1083,6 @@ function drawTileBackground(ctx,x,y,size,radius,fillColor,strokeColor,value){
   ctx.restore();
 }
 
-function roundRect(ctx,x,y,w,h,r,fill,stroke,scale=1){
-  const path=getRoundedRectPath(w,h,r);
-  ctx.save();
-  ctx.translate(x,y);
-  if(scale!==1){
-    const cx=w/2, cy=h/2;
-    ctx.translate(cx,cy);
-    ctx.scale(scale,scale);
-    ctx.translate(-cx,-cy);
-  }
-  if(fill) ctx.fill(path);
-  if(stroke) ctx.stroke(path);
-  ctx.restore();
-}
-
 function getHint(){
   hintDir=engineHint(grid,hintDepth);
   draw();

--- a/games/maze3d/main.js
+++ b/games/maze3d/main.js
@@ -702,7 +702,6 @@ let tiltBaseline = null;
 let tiltActive = false;
 let virtualStickPad = null;
 let virtualStickThumb = null;
-let virtualStickPointerId = null;
 
 const keys = {};
 document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- remove an unused rounded-rectangle helper from the 2048 game implementation
- drop an unused pointer tracking variable from Maze3D's input setup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e69401af788327b771f93c274a267a