### PR TITLE
Fix toon shader vertex color attribute declaration

### DIFF
--- a/games/chess3d/materials/toonRampMaterial.js
+++ b/games/chess3d/materials/toonRampMaterial.js
@@ -13,6 +13,7 @@ const vertexShader = `
   varying vec3 vWorldPos;
   varying vec3 vNormal;
   #ifdef USE_COLOR
+  attribute vec3 color;
   varying vec3 vColor;
   #endif
 


### PR DESCRIPTION
## Summary
- declare the vertex color attribute in the toon ramp vertex shader when USE_COLOR is enabled
- ensure vertex-colored chess pieces compile without GLSL errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e695449ad48327b7480e95f3bef78b