### PR TITLE
Fix resetState autoStart handling

### DIFF
--- a/games/platformer/main.js
+++ b/games/platformer/main.js
@@ -2067,7 +2067,7 @@ export async function boot() {
 
   const keys = new Set();
 
-  function resetState() {
+  function resetState({ autoStart = true } = {}) {
     if (currentLevel) {
       coins = currentLevel.coins.map((coin) => ({ ...coin, collected: false }));
       goal = currentLevel.goal ? { ...currentLevel.goal } : goal;


### PR DESCRIPTION
## Summary
- update resetState to accept an options object so autoStart is defined when toggling pause state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6954088288327b8fd47f86a5c1ce5